### PR TITLE
Unbreak Swagger docs

### DIFF
--- a/autoarena/main.py
+++ b/autoarena/main.py
@@ -24,14 +24,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
 def main() -> FastAPI:
     initialize_logger()
-
-    app = FastAPI(
-        title="AutoArena",
-        lifespan=lifespan,
-        openapi_url=f"/{API_V1_STR}/openapi.json",
-        docs_url=f"/{API_V1_STR}/docs",
-    )
-
+    app = FastAPI(title="AutoArena", lifespan=lifespan, docs_url=f"{API_V1_STR}/docs")
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -39,7 +32,6 @@ def main() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-
     app.include_router(router(), prefix=API_V1_STR)
     app.include_router(ui_router())
     return app


### PR DESCRIPTION
This got lost on an unmerged feature branch somewhere. The config for OpenAPI docs was incorrect, and is fixed here. Verify by visiting http://localhost:8899/api/v1/docs.