### PR TITLE
Add seed script to main CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Apache-2.0 License](https://img.shields.io/pypi/l/autoarena?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0)
 [![CI](https://img.shields.io/github/actions/workflow/status/kolenaIO/autoarena/ci.yml?logo=github&style=flat-square)](https://github.com/kolenaIO/autoarena/actions)
-[![Test Coverage](https://img.shields.io/codecov/c/github/kolenaIO/autoarena?logo=codecov&style=flat-square)](https://app.codecov.io/gh/kolenaIO/autoarena)
+[![Test Coverage](https://img.shields.io/codecov/c/github/kolenaIO/autoarena?logo=codecov&style=flat-square&logoColor=white)](https://app.codecov.io/gh/kolenaIO/autoarena)
 [![PyPI Version](https://img.shields.io/pypi/v/autoarena?logo=python&logoColor=white&style=flat-square)](https://pypi.python.org/pypi/autoarena)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/autoarena.svg?style=flat-square)](https://pypi.org/project/autoarena)
 [![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=flat-square)](https://kolena-autoarena.slack.com)
@@ -87,12 +87,12 @@ run:
 uv venv && source .venv/bin/activate
 uv pip install --all-extras -r pyproject.toml
 uv tool run pre-commit install
-uv run python3 -m autoarena --dev
+uv run python3 -m autoarena serve --dev
 ```
 
 To run AutoArena for development, you will need to run both the backend and frontend service:
 
-- Backend: `uv run python3 -m autoarena --dev` (the `--dev`/`-d` flag enables automatic service reloading when
+- Backend: `uv run python3 -m autoarena serve --dev` (the `--dev`/`-d` flag enables automatic service reloading when
     source files change)
 - Frontend: see [`ui/README.md`](./ui/README.md)
 

--- a/autoarena/__main__.py
+++ b/autoarena/__main__.py
@@ -1,10 +1,6 @@
-import argparse
+import sys
 
-import uvicorn
-
+from autoarena.main import main
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser("autoarena")
-    ap.add_argument("-d", "--dev", action="store_true", help="Run in development mode")
-    args = ap.parse_args()
-    uvicorn.run("autoarena.main:main", host="localhost", port=8899, reload=args.dev, factory=True)
+    main(sys.argv[1:])

--- a/autoarena/main.py
+++ b/autoarena/main.py
@@ -1,37 +1,44 @@
-from contextlib import asynccontextmanager
-from typing import AsyncIterator
+import argparse
+from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from loguru import logger
+import uvicorn
 
-from autoarena.api.router import router
-from autoarena.log import initialize_logger
-from autoarena.service.project import ProjectService
-from autoarena.store.database import get_data_directory
-from autoarena.ui_router import ui_router
-
-API_V1_STR = "/api/v1"
+from autoarena.seed import seed_head_to_heads
 
 
-@asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-    logger.info(f"Using data directory: '{get_data_directory()}'")
-    ProjectService.migrate_all()
-    logger.success("AutoArena ready")
-    yield
+def parse_args(args: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser("autoarena")
+    sp = ap.add_subparsers(dest="command")
+    sp.default = "serve"
 
+    serve_parser = sp.add_parser("serve", help="[Default] Serve the AutoArena app")
+    serve_parser.add_argument("-d", "--dev", action="store_true", help="Run in development mode")
 
-def main() -> FastAPI:
-    initialize_logger()
-    app = FastAPI(title="AutoArena", lifespan=lifespan, docs_url=f"{API_V1_STR}/docs")
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+    seed_parser = sp.add_parser(
+        "seed",
+        help="Seed a project with head-to-heads stored in a CSV or Parquet file",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""\
+    Seed a new project from a CSV or Parquet file where each row represents a head-to-head matchup between two models.
+
+    The following columns are required:
+
+    - `model_a`: name of model A in this head-to-head
+    - `model_b`: name of model B in this head-to-head
+    - `prompt`: the prompt that both models were run on
+    - `response_a`: the response from model A to the prompt
+    - `response_b`: the response from model B to the prompt
+    - `winner`: the winner of the head-to-head, either "A", "B", or "-" for ties""",
     )
-    app.include_router(router(), prefix=API_V1_STR)
-    app.include_router(ui_router())
-    return app
+    seed_parser.add_argument("head_to_heads", type=Path, help="Path to head-to-heads CSV or Parquet file")
+
+    return ap.parse_args(args)
+
+
+def main(args: list[str]) -> None:
+    parsed_args = parse_args(args)
+    if parsed_args.command == "seed":
+        seed_head_to_heads(parsed_args.head_to_heads)
+    if parsed_args.command == "serve":
+        dev = getattr(args, "dev", False)
+        uvicorn.run("autoarena.server:server", host="localhost", port=8899, reload=dev, factory=True)

--- a/autoarena/main.py
+++ b/autoarena/main.py
@@ -19,16 +19,16 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         help="Seed a project with head-to-heads stored in a CSV or Parquet file",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""\
-    Seed a new project from a CSV or Parquet file where each row represents a head-to-head matchup between two models.
+Seed a new project from a CSV or Parquet file where each row represents a head-to-head matchup between two models.
 
-    The following columns are required:
+The following columns are required:
 
-    - `model_a`: name of model A in this head-to-head
-    - `model_b`: name of model B in this head-to-head
-    - `prompt`: the prompt that both models were run on
-    - `response_a`: the response from model A to the prompt
-    - `response_b`: the response from model B to the prompt
-    - `winner`: the winner of the head-to-head, either "A", "B", or "-" for ties""",
+- `model_a`: name of model A in this head-to-head
+- `model_b`: name of model B in this head-to-head
+- `prompt`: the prompt that both models were run on
+- `response_a`: the response from model A to the prompt
+- `response_b`: the response from model B to the prompt
+- `winner`: the winner of the head-to-head, either "A", "B", or "-" for ties""",
     )
     seed_parser.add_argument("head_to_heads", type=Path, help="Path to head-to-heads CSV or Parquet file")
 

--- a/autoarena/seed.py
+++ b/autoarena/seed.py
@@ -1,4 +1,3 @@
-import argparse
 from pathlib import Path
 
 import pandas as pd
@@ -47,23 +46,3 @@ def seed_head_to_heads(head_to_heads: Path) -> None:
 
     # 4. seed elo scores
     EloService.reseed_scores(project_slug)
-
-
-if __name__ == "__main__":
-    ap = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="""\
-Seed a new project from a CSV or Parquet file where each row represents a head-to-head matchup between two models.
-
-The following columns are required:
-
-- `model_a`: name of model A in this head-to-head
-- `model_b`: name of model B in this head-to-head
-- `prompt`: the prompt that both models were run on
-- `response_a`: the response from model A to the prompt
-- `response_b`: the response from model B to the prompt
-- `winner`: the winner of the head-to-head, either "A", "B", or "-" for ties""",
-    )
-    ap.add_argument("head_to_heads", type=Path, help="Path to .csv or .parquet file with head-to-heads and judgements")
-    args = ap.parse_args()
-    seed_head_to_heads(args.head_to_heads)

--- a/autoarena/server.py
+++ b/autoarena/server.py
@@ -1,0 +1,37 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from loguru import logger
+
+from autoarena.api.router import router
+from autoarena.log import initialize_logger
+from autoarena.service.project import ProjectService
+from autoarena.store.database import get_data_directory
+from autoarena.ui_router import ui_router
+
+API_V1_STR = "/api/v1"
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    logger.info(f"Using data directory: '{get_data_directory()}'")
+    ProjectService.migrate_all()
+    logger.success("AutoArena ready")
+    yield
+
+
+def server() -> FastAPI:
+    initialize_logger()
+    app = FastAPI(title="AutoArena", lifespan=lifespan, docs_url=f"{API_V1_STR}/docs")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(router(), prefix=API_V1_STR)
+    app.include_router(ui_router())
+    return app

--- a/autoarena/store/utils.py
+++ b/autoarena/store/utils.py
@@ -1,2 +1,11 @@
+import pandas as pd
+
+
 def id_slug(a: int, b: int) -> str:
     return f"{int(min(a, b))}-{int(max(a, b))}"  # matches duckdb implementation in 000__schema.sql
+
+
+def check_required_columns(df: pd.DataFrame, required_columns: list[str]) -> None:
+    missing_columns = set(required_columns) - set(df.columns)
+    if len(missing_columns) > 0:
+        raise ValueError(f"Missing {missing_columns} required column(s): {missing_columns}")

--- a/autoarena/store/utils.py
+++ b/autoarena/store/utils.py
@@ -8,4 +8,4 @@ def id_slug(a: int, b: int) -> str:
 def check_required_columns(df: pd.DataFrame, required_columns: list[str]) -> None:
     missing_columns = set(required_columns) - set(df.columns)
     if len(missing_columns) > 0:
-        raise ValueError(f"Missing {missing_columns} required column(s): {missing_columns}")
+        raise ValueError(f"Missing {len(missing_columns)} required column(s): {missing_columns}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,6 +13,7 @@ from autoarena.store.database import set_data_directory
 @pytest.fixture(scope="function")
 def test_data_directory() -> Iterator[Path]:
     data_directory = Path(__file__).parent / "data"
+    data_directory.mkdir(parents=True, exist_ok=True)
     set_data_directory(data_directory)
     try:
         yield data_directory

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,7 @@ from autoarena.server import server, API_V1_STR
 from autoarena.store.database import set_data_directory
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def test_data_directory() -> Iterator[Path]:
     data_directory = Path(__file__).parent / "data"
     set_data_directory(data_directory)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,7 @@ from typing import Iterator
 import pytest
 from fastapi.testclient import TestClient
 
-from autoarena.main import main, API_V1_STR
+from autoarena.server import server, API_V1_STR
 from autoarena.store.database import set_data_directory
 
 
@@ -22,13 +22,13 @@ def test_data_directory() -> Iterator[Path]:
 
 @pytest.fixture(scope="function")
 def client() -> Iterator[TestClient]:
-    with TestClient(main()) as client:
+    with TestClient(server()) as client:
         yield client
 
 
 @pytest.fixture(scope="function")
 def api_v1_client(test_data_directory: Path) -> Iterator[TestClient]:
-    with TestClient(main(), base_url=f"http://testserver{API_V1_STR}") as client:
+    with TestClient(server(), base_url=f"http://testserver{API_V1_STR}") as client:
         yield client
 
 
@@ -46,5 +46,5 @@ def project_slug(api_v1_client: TestClient, test_data_directory: Path) -> Iterat
 
 @pytest.fixture(scope="function")
 def project_client(project_slug: Path) -> Iterator[TestClient]:
-    with TestClient(main(), base_url=f"http://testserver{API_V1_STR}/project/{project_slug}") as client:
+    with TestClient(server(), base_url=f"http://testserver{API_V1_STR}/project/{project_slug}") as client:
         yield client

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -13,6 +13,14 @@ from autoarena.service.model import ModelService
 from autoarena.service.project import ProjectService
 
 
+@pytest.mark.parametrize("arg", ["-h", "--help"])
+def test__cli__help(arg: str, test_data_directory: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as e:
+        main([arg])
+    assert e.value.code == 0
+    assert "usage: autoarena" in capsys.readouterr().out
+
+
 def test__cli__seed(test_data_directory: Path) -> None:
     h2h_records = [
         dict(model_a="a", model_b="b", prompt="example", response_a="response a", response_b="response b", winner="-"),

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,10 +1,8 @@
 import tempfile
-from io import StringIO
 from pathlib import Path
 
 import pandas as pd
 import pytest
-from loguru import logger
 
 from autoarena.api import api
 from autoarena.main import main
@@ -69,19 +67,8 @@ def test__cli__seed__missing_columns(test_data_directory: None) -> None:
             assert "Missing 2 required column(s)" in str(e)
 
 
-@pytest.mark.skip(reason="Server runs forever, need to figure out a way to stop it after we've verified that it starts")
-def test__cli__serve__no_argument(test_data_directory: None) -> None:
-    logs = StringIO()
-    logger.add(logs)
-    main([])
-
-
-@pytest.mark.skip
-def test__cli__serve(test_data_directory: None) -> None:
-    main(["serve"])
-
-
-@pytest.mark.skip
-@pytest.mark.parametrize("arg", ["-d", "--dev"])
-def test__cli__serve__dev(test_data_directory: None, arg: str) -> None:
-    main(["serve", arg])
+# TODO
+@pytest.mark.skip(reason="Server runs forever -- figure out a way to kill after asserting that it started up correctly")
+@pytest.mark.parametrize("args", [[], ["serve"], ["serve", "-d"], ["serve", "--dev"]])
+def test__cli__serve(args: list[str], test_data_directory: None) -> None:
+    main(args)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,41 @@
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from autoarena.api import api
+from autoarena.main import main
+from autoarena.service.head_to_head import HeadToHeadService
+from autoarena.service.model import ModelService
+from autoarena.service.project import ProjectService
+
+
+def test__cli__seed(test_data_directory: Path) -> None:
+    h2h_records = [
+        dict(model_a="a", model_b="b", prompt="example", response_a="response a", response_b="response b", winner="-"),
+        dict(model_a="b", model_b="a", prompt="another", response_a="from b", response_b="from a", winner="A"),
+        dict(model_a="c", model_b="a", prompt="vs. c", response_a="from c", response_b="from a", winner="A"),
+    ]
+    df_h2h_input = pd.DataFrame.from_records(h2h_records)
+    with tempfile.NamedTemporaryFile(suffix=".csv") as f:
+        filename = f.name
+        df_h2h_input.to_csv(f, index=False)
+        main(["seed", filename])
+
+    projects = ProjectService.get_all()
+    project_slug = Path(filename).stem
+    assert len(projects) == 1
+    assert projects[0].slug == project_slug
+
+    models = ModelService.get_all(project_slug)
+    assert {m.name for m in models} == set(df_h2h_input.model_a) | set(df_h2h_input.model_b)
+    for model in models:
+        assert model.n_responses > 0
+        assert model.n_votes > 0
+        assert model.q025 is not None
+        assert model.q975 is not None
+        df_h2h_model = HeadToHeadService.get_df(project_slug, api.HeadToHeadsRequest(model_a_id=model.id))
+        df_h2h_input_model = df_h2h_input[(df_h2h_input.model_a == model.name) | (df_h2h_input.model_b == model.name)]
+        assert len(df_h2h_model) == len(df_h2h_input_model)
+        assert all(df_h2h_model.history.apply(lambda h: len(h) == 1))
+        assert all(df_h2h_model.history.apply(lambda h: h[0]["judge_name"] == "Human"))


### PR DESCRIPTION
Start the pattern of `python -m autoarena {command}` with the `seed` command to seed a project with data from a file with many judged head-to-heads.

The main service still runs as `python -m autoarena`, but can be invoked with arguments as `python -m autoarena serve {...}`.