### PR TITLE
Use OpenAI response headers for better rate limiting

### DIFF
--- a/autoarena/judge/openai.py
+++ b/autoarena/judge/openai.py
@@ -39,8 +39,8 @@ class OpenAIJudge(AutomatedJudge):
         self._handle_rate_limit(dict(response_raw.headers))
         return response.choices[0].message.content
 
-    # TODO: this should handle backoff for request rate limit, but the API surfaces the per-day, not the per-minute
-    #  request rate limits and those aren't really actionable (hours until reset)
+    # NOTE: ideally this would handle backoff for request rate limit, but the API surfaces the per-day, not the
+    #  per-minute request rate limits and those aren't really actionable (hours until reset)
     @staticmethod
     def _handle_rate_limit(headers: dict[str, str]) -> None:
         try:

--- a/autoarena/judge/openai.py
+++ b/autoarena/judge/openai.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from openai import OpenAI
 
 from autoarena.judge.base import AutomatedJudge
@@ -18,7 +19,7 @@ class OpenAIJudge(AutomatedJudge):
     # OpenAI has different tiers and different rate limits for different models, choose a safeish value
     @rate_limit(n_calls=1_000, n_seconds=60)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
-        response = self._client.chat.completions.create(
+        response_raw = self._client.chat.completions.with_raw_response.create(
             model=self.model_name,
             messages=[
                 dict(role="system", content=self.system_prompt),
@@ -26,6 +27,13 @@ class OpenAIJudge(AutomatedJudge):
             ],
             max_tokens=self.MAX_TOKENS,
         )
+        call_limit = int(response_raw.headers.get("x-ratelimit-remaining-requests", 1e6))
+        if call_limit < 50:
+            logger.warning(f"Approaching OpenAI request rate limit: {call_limit} remaining")
+        token_limit = int(response_raw.headers.get("x-ratelimit-remaining-tokens", 1e6))
+        if token_limit < 1000:
+            logger.warning(f"Approaching OpenAI token rate limit: {token_limit} remaining")
+        response = response_raw.parse()
         self.n_calls += 1
         self.total_input_tokens += response.usage.prompt_tokens
         self.total_output_tokens += response.usage.completion_tokens

--- a/autoarena/judge/wrapper.py
+++ b/autoarena/judge/wrapper.py
@@ -2,7 +2,7 @@ from typing import Callable, TypeVar
 
 import numpy as np
 from loguru import logger
-from tenacity import retry, wait_random_exponential, stop_after_attempt, RetryCallState
+from tenacity import retry, stop_after_attempt, RetryCallState, wait_exponential
 
 from autoarena.judge.base import AutomatedJudge
 from autoarena.judge.utils import ACCEPTABLE_RESPONSES
@@ -82,7 +82,8 @@ def fixing_wrapper(judge_class: type[T]) -> type[T]:
 def retrying_wrapper(judge_class: type[T]) -> type[T]:
     class RetryingJudge(judge_class):  # type: ignore
         def judge(self, prompt: str, response_a: str, response_b: str) -> str:
-            @retry(wait=wait_random_exponential(min=2, max=10), stop=stop_after_attempt(3), after=self._log_retry)
+            # wait 0, 1, 2, 4, 8, 16, 32 seconds
+            @retry(wait=wait_exponential(min=0, max=32), stop=stop_after_attempt(7), after=self._log_retry)
             def judge_inner(p: str, ra: str, rb: str) -> str:
                 return super(RetryingJudge, self).judge(p, ra, rb)
 

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -94,76 +94,76 @@ class TaskService:
         task_id = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message).id
         logger.info(message)
 
-        try:
-            # 2. instantiate judge(s)
-            TaskService.update(project_slug, task_id, f"Using {len(enabled_auto_judges)} judge(s):")
-            for j in enabled_auto_judges:
-                TaskService.update(project_slug, task_id, f"  * {j.name}")
-            wrappers = [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
-            judges = [judge_factory(j, wrappers=wrappers) for j in enabled_auto_judges]
+        with ThreadedExecutor(8) as executor:
+            try:
+                # 2. instantiate judge(s)
+                TaskService.update(project_slug, task_id, f"Using {len(enabled_auto_judges)} judge(s):")
+                for j in enabled_auto_judges:
+                    TaskService.update(project_slug, task_id, f"  * {j.name}")
+                wrappers = [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
+                judges = [judge_factory(j, wrappers=wrappers) for j in enabled_auto_judges]
 
-            # 3. get pairs eligible for judging
-            df_h2hs = [HeadToHeadService.get_df(project_slug, api.HeadToHeadsRequest(model_a_id=m.id)) for m in models]
-            df_h2h = pd.concat(df_h2hs)
-            if len(df_h2h) == 0:
-                message = "No head-to-heads found, exiting"
-                logger.warning(message)
-                TaskService.update(project_slug, task_id, message, status=api.TaskStatus.COMPLETED, progress=1)
-                return
-            df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
-            df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
-            message = f"Found {len(df_h2h)} head-to-heads versus {len(set(df_h2h.model_b_id))} model(s) to judge"
-            TaskService.update(project_slug, task_id, message)
+                # 3. get pairs eligible for judging
+                h2h_requests = [api.HeadToHeadsRequest(model_a_id=m.id) for m in models]
+                df_h2hs = [HeadToHeadService.get_df(project_slug, request) for request in h2h_requests]
+                df_h2h = pd.concat(df_h2hs)
+                if len(df_h2h) == 0:
+                    message = "No head-to-heads found, exiting"
+                    logger.warning(message)
+                    TaskService.update(project_slug, task_id, message, status=api.TaskStatus.COMPLETED, progress=1)
+                    return
+                df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
+                df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
+                message = f"Found {len(df_h2h)} head-to-heads versus {len(set(df_h2h.model_b_id))} model(s) to judge"
+                TaskService.update(project_slug, task_id, message)
 
-            # 4. stream judgement requests
-            head_to_heads = [
-                api.HeadToHead(**r)
-                for _, r in df_h2h[["prompt", "response_a_id", "response_a", "response_b_id", "response_b"]].iterrows()
-            ]
-            executor = ThreadedExecutor(4)
-            responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
-            n_h2h = len(head_to_heads)
-            n_total = n_h2h * len(judges)
-            t_start_judging = time.time()
-            for judge, h2h, winner in executor.execute(judges, head_to_heads):
-                responses[judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
-                n_this_judge = len(responses[judge.name])
-                n_responses = sum(len(r) for r in responses.values())
-                progress = 0.95 * (n_responses / n_total)
-                if n_this_judge % 10 == 0:
-                    message = f"Judged {n_this_judge} of {n_h2h} with '{judge.name}'"
-                    TaskService.update(project_slug, task_id, message, progress=progress)
-                if n_this_judge == len(head_to_heads):
-                    message = (
-                        f"Judge '{judge.name}' finished judging {n_h2h} head-to-heads in "
-                        f"{time.time() - t_start_judging:0.1f} seconds"
-                    )
-                    TaskService.update(project_slug, task_id, message, progress=progress)
-                    judge.log_usage()
+                # 4. stream judgement requests
+                h2h_columns = ["prompt", "response_a_id", "response_a", "response_b_id", "response_b"]
+                head_to_heads = [api.HeadToHead(**r) for _, r in df_h2h[h2h_columns].iterrows()]
+                responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
+                n_h2h = len(head_to_heads)
+                n_total = n_h2h * len(judges)
+                t_start_judging = time.time()
+                for judge, h2h, winner in executor.execute(judges, head_to_heads):
+                    responses[judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
+                    n_this_judge = len(responses[judge.name])
+                    n_responses = sum(len(r) for r in responses.values())
+                    progress = 0.95 * (n_responses / n_total)
+                    if n_this_judge % 10 == 0:
+                        message = f"Judged {n_this_judge} of {n_h2h} with '{judge.name}'"
+                        TaskService.update(project_slug, task_id, message, progress=progress)
+                    if n_this_judge == len(head_to_heads):
+                        message = (
+                            f"Judge '{judge.name}' finished judging {n_h2h} head-to-heads in "
+                            f"{time.time() - t_start_judging:0.1f} seconds"
+                        )
+                        TaskService.update(project_slug, task_id, message, progress=progress)
+                        judge.log_usage()
 
-            # TODO: stream to database?
-            # 5. upload judgements to database
-            judge_id_by_name = {j.name: j.id for j in enabled_auto_judges}
-            dfs_h2h_judged = []
-            for judge_name, judge_responses in responses.items():
-                df_h2h_judged = df_h2h.copy()
-                df_h2h_judged["judge_id"] = judge_id_by_name[judge_name]
-                df_judgement = pd.DataFrame(judge_responses, columns=["response_a_id", "response_b_id", "winner"])
-                df_h2h_judged = pd.merge(df_h2h_judged, df_judgement, on=["response_a_id", "response_b_id"], how="left")
-                dfs_h2h_judged.append(df_h2h_judged)
-            # randomize order of ratings to avoid biased elos when multiple judges are present
-            df_h2h_judged_all = pd.concat(dfs_h2h_judged).sample(frac=1.0)  # noqa: F841
-            HeadToHeadService.upload_head_to_heads(project_slug, df_h2h_judged_all)
+                # TODO: stream to database?
+                # 5. upload judgements to database
+                judge_id_by_name = {j.name: j.id for j in enabled_auto_judges}
+                dfs_h2h_judged = []
+                for judge_name, judge_responses in responses.items():
+                    df_h2h_judged = df_h2h.copy()
+                    df_h2h_judged["judge_id"] = judge_id_by_name[judge_name]
+                    response_columns = ["response_a_id", "response_b_id"]
+                    df_judgement = pd.DataFrame(judge_responses, columns=[*response_columns, "winner"])
+                    df_h2h_judged = pd.merge(df_h2h_judged, df_judgement, on=response_columns, how="left")
+                    dfs_h2h_judged.append(df_h2h_judged)
+                # randomize order of ratings to avoid biased elos when multiple judges are present
+                df_h2h_judged_all = pd.concat(dfs_h2h_judged).sample(frac=1.0)  # noqa: F841
+                HeadToHeadService.upload_head_to_heads(project_slug, df_h2h_judged_all)
 
-            # 6. recompute elo scores and confidence intervals
-            TaskService.update(project_slug, task_id, "Recomputing leaderboard rankings", progress=0.96)
-            EloService.reseed_scores(project_slug)
-            message = f"Completed automated judging in {time.time() - t_start:0.1f} seconds"
-            TaskService.update(project_slug, task_id, message, progress=1, status=api.TaskStatus.COMPLETED)
-            logger.info(message)
-        except Exception as e:
-            TaskService.update(project_slug, task_id, f"Failed ({e})", status=api.TaskStatus.FAILED)
-            message = "See AutoArena service logs for more information"
-            TaskService.update(project_slug, task_id, message, status=api.TaskStatus.FAILED)
-            logger.error(f"Automated judgement failed: {e}")
-            raise e
+                # 6. recompute elo scores and confidence intervals
+                TaskService.update(project_slug, task_id, "Recomputing leaderboard rankings", progress=0.96)
+                EloService.reseed_scores(project_slug)
+                message = f"Completed automated judging in {time.time() - t_start:0.1f} seconds"
+                TaskService.update(project_slug, task_id, message, progress=1, status=api.TaskStatus.COMPLETED)
+                logger.info(message)
+            except Exception as e:
+                TaskService.update(project_slug, task_id, f"Failed ({e})", status=api.TaskStatus.FAILED)
+                message = "See AutoArena service logs for more information"
+                TaskService.update(project_slug, task_id, message, status=api.TaskStatus.FAILED)
+                logger.error(f"Automated judgement failed: {e}")
+                raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "transformers>=4,<5",
     "torch>=2,<3",
     "together>=1,<2",
+    "pytimeparse>=1.1.8",
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/judge/test_judge.py
+++ b/tests/integration/judge/test_judge.py
@@ -2,7 +2,7 @@ import pytest
 
 from autoarena.api import api
 from autoarena.judge.factory import judge_factory
-from autoarena.judge.wrapper import cleaning_wrapper
+from autoarena.judge.wrapper import cleaning_wrapper, retrying_wrapper
 from tests.integration.judge.conftest import api_judge, TEST_JUDGE_MODEL_NAMES
 
 
@@ -20,7 +20,7 @@ from tests.integration.judge.conftest import api_judge, TEST_JUDGE_MODEL_NAMES
 )
 def test__judge__automated(judge_type: api.JudgeType) -> None:
     model_name = TEST_JUDGE_MODEL_NAMES[judge_type]
-    judge_instance = judge_factory(api_judge(judge_type, model_name), wrappers=[cleaning_wrapper])
+    judge_instance = judge_factory(api_judge(judge_type, model_name), wrappers=[retrying_wrapper, cleaning_wrapper])
     assert judge_instance.judge("What is 2+2?", "4", "100 million") == "A"
     assert judge_instance.n_calls == 1
     assert judge_instance.total_input_tokens > 0

--- a/tests/unit/judge/test_judge.py
+++ b/tests/unit/judge/test_judge.py
@@ -1,0 +1,26 @@
+import time
+from io import StringIO
+
+from loguru import logger
+from pytimeparse.timeparse import timeparse
+
+from autoarena.judge.openai import OpenAIJudge
+
+
+def test__judge__openai__handle_rate_limit() -> None:
+    headers = {
+        "x-ratelimit-remaining-requests": "10",
+        "x-ratelimit-remaining-tokens": "1000",
+        "x-ratelimit-reset-requests": "20h0m29.594s",
+        "x-ratelimit-reset-tokens": "0.1s",
+    }
+    log_stream = StringIO()
+    logger.add(log_stream)
+    t0 = time.time()
+    OpenAIJudge._handle_rate_limit(headers)
+    t1 = time.time()
+    log_stream.seek(0)
+    logs = log_stream.read()
+    assert "Approaching OpenAI request rate limit" in logs
+    assert "Approaching OpenAI token rate limit" in logs
+    assert t1 - t0 > timeparse(headers["x-ratelimit-reset-tokens"])


### PR DESCRIPTION
Most judging tasks are bound by the token rate limit, which is nicely exposed as response headers. Use these to inform the user when rate limits are hit, and to back off for the appropriate amount of time while they reset.

Also update executor interface to use context manager ensuring thread pool shutdown on exit (successful or not).