### PR TITLE
Drop empty prompts/responses during model upload

### DIFF
--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -89,6 +89,10 @@ class ModelService:
             check_required_columns(df_response, ["prompt", "response"])
         except ValueError as e:
             raise BadRequestError(str(e))
+        n_input = len(df_response)
+        df_response = df_response.copy().dropna(subset=["prompt", "response"])
+        if len(df_response) != n_input:
+            logger.warning(f"Dropped {n_input - len(df_response)} responses with empty prompt or response values")
         logger.info(f"Uploading {len(df_response)} responses from model '{model_name}'")
         with ProjectService.connect(project_slug) as conn:
             ((new_model_id,),) = conn.execute(

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -50,7 +50,7 @@ def test__models__upload__failed(project_client: TestClient, df_bad: pd.DataFram
         (pd.DataFrame([("p", "r"), ("p2", "")], columns=["prompt", "response"]), 1),
         (pd.DataFrame([("p", "r"), ("", "r")], columns=["prompt", "response"]), 1),
         (pd.DataFrame([("p", ""), ("p2", "")], columns=["prompt", "response"]), 2),
-        (pd.DataFrame([("p", ""), ("p2", "")], columns=["prompt", "response"]), 2),
+        (pd.DataFrame([("", "r"), ("p2", "")], columns=["prompt", "response"]), 2),
     ],
 )
 def test__models__upload__missing_values(project_client: TestClient, df: pd.DataFrame, n_dropped: int) -> None:

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -44,6 +44,22 @@ def test__models__upload__failed(project_client: TestClient, df_bad: pd.DataFram
     assert f"Missing {len(missing)} required column(s)" in response.json()["detail"]
 
 
+@pytest.mark.parametrize(
+    "df,n_dropped",
+    [
+        (pd.DataFrame([("p", "r"), ("p2", "")], columns=["prompt", "response"]), 1),
+        (pd.DataFrame([("p", "r"), ("", "r")], columns=["prompt", "response"]), 1),
+        (pd.DataFrame([("p", ""), ("p2", "")], columns=["prompt", "response"]), 2),
+        (pd.DataFrame([("p", ""), ("p2", "")], columns=["prompt", "response"]), 2),
+    ],
+)
+def test__models__upload__missing_values(project_client: TestClient, df: pd.DataFrame, n_dropped: int) -> None:
+    body = construct_upload_model_body(dict(example=df))
+    models = project_client.post("/model", data=body.data, files=body.files).json()
+    assert len(models) == 1
+    assert models[0]["n_responses"] == len(df) - n_dropped
+
+
 def test__models__upload__multiple(project_client: TestClient) -> None:
     body = construct_upload_model_body(dict(a=DF_RESPONSE, b=DF_RESPONSE_B))
     models = project_client.post("/model", data=body.data, files=body.files).json()


### PR DESCRIPTION
Drop and warn rather than letting empty prompts or responses in crash the entire upload.