### PR TITLE
Add options to show all/with votes/and without votes on head-to-head tab

### DIFF
--- a/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
@@ -7,6 +7,7 @@ import { useModelResponses } from '../../hooks/useModelResponses.ts';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { useUrlState } from '../../hooks/useUrlState.ts';
+import { useModel } from '../../hooks/useModel.ts';
 import { ControlBar } from './ControlBar.tsx';
 
 type Props = {
@@ -14,6 +15,7 @@ type Props = {
 };
 export function HeadToHeadSingleModel({ modelId }: Props) {
   const { projectSlug } = useUrlState();
+  const { data: model } = useModel(projectSlug, modelId);
   const { data: modelResponses, isLoading } = useModelResponses({ projectSlug, modelId });
   const [responseIndex, setResponseIndex] = useState(0);
   const { ref: controlBarRef, height } = useElementSize<HTMLDivElement>();
@@ -33,15 +35,16 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
     ['ArrowRight', navigateNext],
   ]);
 
+  const modelName = model != null ? `'${model.name}'` : 'selected model';
   const iconProps = { size: 18 };
   return !isLoading && nResponses === 0 ? (
-    <NonIdealState IconComponent={IconCactus} description="No responses from selected model" />
+    <NonIdealState IconComponent={IconCactus} description={`No responses from ${modelName}`} />
   ) : !isLoading ? (
     <>
       <Stack pb={height + 32}>
         <Group justify="flex-end">
           <Text c="dimmed" size="sm" fs="italic">
-            {pluralize(nResponses, 'response')} from selected model
+            {pluralize(nResponses, 'response')} from {modelName}
           </Text>
         </Group>
         <Paper withBorder p="md" bg="gray.0" style={{ overflow: 'auto' }}>

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -92,121 +92,132 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
   }, [showVoteHistory, headToHead]);
 
   const iconProps = { size: 18 };
-  return !isLoading && nHeadToHeads === 0 ? (
-    <NonIdealState IconComponent={IconCactus} description="No head-to-head matchups between selected models" />
-  ) : !isLoading && headToHeadIndex > nHeadToHeads - 1 ? (
-    <NonIdealState
-      IconComponent={IconBalloon}
-      description={
-        <Stack>
-          <Text>Judged all {nHeadToHeads.toLocaleString()} head-to-head matchups between selected models</Text>
-          <Button onClick={() => navigate(`/project/${projectSlug}`)}>View Leaderboard</Button>
-        </Stack>
-      }
-    />
-  ) : !isLoading ? (
-    <>
-      <Stack pb={height + 32}>
-        <Group justify="space-between">
-          <Checkbox
-            checked={showOnlyJudged}
-            onChange={toggleShowOnlyJudged}
-            label={
-              <Text inherit c="dimmed">
-                Only show head-to-heads with votes
-              </Text>
-            }
-          />
-          <Text c="dimmed" size="sm" fs="italic">
-            {showOnlyJudged
-              ? `${pluralize(nHeadToHeads, 'head-to-head')} with votes between selected models (${nHeadToHeadsTotal.toLocaleString()} total)`
-              : `${pluralize(nHeadToHeads, 'head-to-head')} between selected models`}
-          </Text>
-        </Group>
-        <Paper withBorder p="md" bg="gray.0" style={{ overflow: 'auto' }}>
-          <MarkdownContent>{`**Prompt:** ${headToHead?.prompt}`}</MarkdownContent>
-        </Paper>
-        <SimpleGrid cols={2}>
-          <Paper withBorder p="md" flex={1} style={{ overflow: 'auto' }}>
-            <MarkdownContent>{`**Response A:**\n\n${headToHead?.response_a}`}</MarkdownContent>
-          </Paper>
-          <Paper withBorder p="md" flex={1} style={{ overflow: 'auto' }}>
-            <MarkdownContent>{`**Response B:**\n\n${headToHead?.response_b}`}</MarkdownContent>
-          </Paper>
-        </SimpleGrid>
-      </Stack>
+  return (
+    <Stack pb={height + 32}>
+      <Group justify="space-between">
+        <Checkbox
+          checked={showOnlyJudged}
+          onChange={toggleShowOnlyJudged}
+          label={
+            <Text inherit c="dimmed">
+              Only show head-to-heads with votes
+            </Text>
+          }
+        />
+        <Text c="dimmed" size="sm" fs="italic">
+          {showOnlyJudged
+            ? `${pluralize(nHeadToHeads, 'head-to-head')} with votes between selected models (${nHeadToHeadsTotal.toLocaleString()} total)`
+            : `${pluralize(nHeadToHeads, 'head-to-head')} between selected models`}
+        </Text>
+      </Group>
 
-      <ControlBar ref={controlBarRef}>
-        <Stack align="center" gap="xs">
-          <Text fw="bold">Which response is better?</Text>
-          <SimpleGrid cols={5} spacing="xs">
-            <Button
-              leftSection={<Kbd>p</Kbd>}
-              variant="subtle"
-              color="gray"
-              onClick={navigatePrevious}
-              disabled={headToHeadIndex < 1}
-              h="100%"
-            >
-              Previous
-            </Button>
-            <Button leftSection={<IconArrowLeft {...iconProps} />} onClick={submitVote('A')} h="100%">
-              Left is Better
-            </Button>
-            <Stack gap={4}>
-              <Button size="compact-xs" leftSection={<IconArrowUp {...iconProps} />} onClick={submitVote('-')}>
-                Both are Good
-              </Button>
-              <Button size="compact-xs" leftSection={<IconArrowDown {...iconProps} />} onClick={submitVote('-')}>
-                Both are Bad
-              </Button>
+      {!isLoading && nHeadToHeads === 0 ? (
+        <NonIdealState
+          IconComponent={IconCactus}
+          description={
+            <Stack align="center" gap="xs">
+              <Text inherit>No head-to-heads {showOnlyJudged && 'with votes '}between selected models</Text>
+              {showOnlyJudged && <Text>({pluralize(nHeadToHeadsTotal, 'total head-to-head')})</Text>}
             </Stack>
-            <Button rightSection={<IconArrowRight {...iconProps} />} onClick={submitVote('B')} h="100%">
-              Right is Better
-            </Button>
-            <Button
-              rightSection={<Kbd>n</Kbd>}
-              variant="subtle"
-              color="gray"
-              onClick={navigateNext}
-              disabled={headToHeadIndex >= nHeadToHeads - 1}
-              h="100%"
-            >
-              Next
-            </Button>
-            {showVoteHistory && (
-              <>
-                <div />
-                {[votesA, votesTie, votesB].map((votes, i) => (
-                  <Stack key={i} gap="xs" align="center" fz="xs">
-                    {votes.map((judge, i) => (
-                      <Text key={i} span inherit>
-                        {judge}
-                      </Text>
-                    ))}
-                  </Stack>
-                ))}
-                <div />
-              </>
-            )}
+          }
+        />
+      ) : !isLoading && headToHeadIndex > nHeadToHeads - 1 ? (
+        <NonIdealState
+          IconComponent={IconBalloon}
+          description={
+            <Stack>
+              <Text>Judged all {nHeadToHeads.toLocaleString()} head-to-head matchups between selected models</Text>
+              <Button onClick={() => navigate(`/project/${projectSlug}`)}>View Leaderboard</Button>
+            </Stack>
+          }
+        />
+      ) : !isLoading ? (
+        <>
+          <Paper withBorder p="md" bg="gray.0" style={{ overflow: 'auto' }}>
+            <MarkdownContent>{`**Prompt:** ${headToHead?.prompt}`}</MarkdownContent>
+          </Paper>
+          <SimpleGrid cols={2}>
+            <Paper withBorder p="md" flex={1} style={{ overflow: 'auto' }}>
+              <MarkdownContent>{`**Response A:**\n\n${headToHead?.response_a}`}</MarkdownContent>
+            </Paper>
+            <Paper withBorder p="md" flex={1} style={{ overflow: 'auto' }}>
+              <MarkdownContent>{`**Response B:**\n\n${headToHead?.response_b}`}</MarkdownContent>
+            </Paper>
           </SimpleGrid>
-        </Stack>
 
-        <Box p="md" style={{ position: 'fixed', bottom: 0, right: 0 }}>
-          <Button
-            variant="subtle"
-            color="gray"
-            size="xs"
-            onClick={toggleShowVoteHistory}
-            disabled={!hasVoteHistory}
-            rightSection={<Kbd size="xs">h</Kbd>}
-          >
-            {!hasVoteHistory ? 'No' : showVoteHistory ? 'Hide' : 'Show'} Vote History
-          </Button>
-        </Box>
-      </ControlBar>
-    </>
-  ) : (
-    <></>
+          <ControlBar ref={controlBarRef}>
+            <Stack align="center" gap="xs">
+              <Text fw="bold">Which response is better?</Text>
+              <SimpleGrid cols={5} spacing="xs">
+                <Button
+                  leftSection={<Kbd>p</Kbd>}
+                  variant="subtle"
+                  color="gray"
+                  onClick={navigatePrevious}
+                  disabled={headToHeadIndex < 1}
+                  h="100%"
+                >
+                  Previous
+                </Button>
+                <Button leftSection={<IconArrowLeft {...iconProps} />} onClick={submitVote('A')} h="100%">
+                  Left is Better
+                </Button>
+                <Stack gap={4}>
+                  <Button size="compact-xs" leftSection={<IconArrowUp {...iconProps} />} onClick={submitVote('-')}>
+                    Both are Good
+                  </Button>
+                  <Button size="compact-xs" leftSection={<IconArrowDown {...iconProps} />} onClick={submitVote('-')}>
+                    Both are Bad
+                  </Button>
+                </Stack>
+                <Button rightSection={<IconArrowRight {...iconProps} />} onClick={submitVote('B')} h="100%">
+                  Right is Better
+                </Button>
+                <Button
+                  rightSection={<Kbd>n</Kbd>}
+                  variant="subtle"
+                  color="gray"
+                  onClick={navigateNext}
+                  disabled={headToHeadIndex >= nHeadToHeads - 1}
+                  h="100%"
+                >
+                  Next
+                </Button>
+                {showVoteHistory && (
+                  <>
+                    <div />
+                    {[votesA, votesTie, votesB].map((votes, i) => (
+                      <Stack key={i} gap="xs" align="center" fz="xs">
+                        {votes.map((judge, i) => (
+                          <Text key={i} span inherit>
+                            {judge}
+                          </Text>
+                        ))}
+                      </Stack>
+                    ))}
+                    <div />
+                  </>
+                )}
+              </SimpleGrid>
+            </Stack>
+
+            <Box p="md" style={{ position: 'fixed', bottom: 0, right: 0 }}>
+              <Button
+                variant="subtle"
+                color="gray"
+                size="xs"
+                onClick={toggleShowVoteHistory}
+                disabled={!hasVoteHistory}
+                rightSection={<Kbd size="xs">h</Kbd>}
+              >
+                {!hasVoteHistory ? 'No' : showVoteHistory ? 'Hide' : 'Show'} Vote History
+              </Button>
+            </Box>
+          </ControlBar>
+        </>
+      ) : (
+        <></>
+      )}
+    </Stack>
   );
 }

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -16,6 +16,7 @@ import { useSubmitHeadToHeadVote } from '../../hooks/useSubmitHeadToHeadVote.ts'
 import { pluralize } from '../../lib/string.ts';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { NonIdealState } from '../NonIdealState.tsx';
+import { useModel } from '../../hooks/useModel.ts';
 import { ControlBar } from './ControlBar.tsx';
 
 type ShowMode = 'All' | 'With Votes' | 'Without Votes';
@@ -29,6 +30,8 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
   const navigate = useNavigate();
   const [showVoteHistory, { toggle: toggleShowVoteHistory }] = useDisclosure(false);
   const { data: allHeadToHeads, isLoading } = useHeadToHeads({ projectSlug, modelAId, modelBId });
+  const { data: modelA } = useModel(projectSlug, modelAId);
+  const { data: modelB } = useModel(projectSlug, modelBId);
   const { mutate: submitJudgement } = useSubmitHeadToHeadVote({ projectSlug });
   const [headToHeadIndex, setHeadToHeadIndex] = useState(0);
   const { ref: controlBarRef, height } = useElementSize<HTMLDivElement>();
@@ -94,6 +97,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
     );
   }, [showVoteHistory, headToHead]);
 
+  const modelNames = modelA != null && modelB != null ? `'${modelA.name}' and '${modelB.name}'` : 'selected models';
   const iconProps = { size: 18 };
   return (
     <Stack pb={height + 32}>
@@ -128,8 +132,8 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
         </Paper>
         <Text c="dimmed" size="sm" fs="italic">
           {showMode === 'All'
-            ? `${pluralize(nHeadToHeads, 'head-to-head')} between selected models`
-            : `${pluralize(nHeadToHeads, 'head-to-head')} ${showMode.toLowerCase()} between selected models (${nHeadToHeadsTotal.toLocaleString()} total)`}
+            ? `${pluralize(nHeadToHeads, 'head-to-head')} between ${modelNames}`
+            : `${pluralize(nHeadToHeads, 'head-to-head')} ${showMode.toLowerCase()} between ${modelNames} (${nHeadToHeadsTotal.toLocaleString()} total)`}
         </Text>
       </Group>
 
@@ -139,7 +143,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
           description={
             <Stack align="center" gap="xs">
               <Text inherit>
-                No head-to-heads {showMode !== 'All' && `${showMode.toLowerCase()} `}between selected models
+                No head-to-heads {showMode !== 'All' && `${showMode.toLowerCase()} `}between {modelNames}
               </Text>
               {showMode !== 'All' && <Text>({pluralize(nHeadToHeadsTotal, 'total head-to-head')})</Text>}
             </Stack>
@@ -150,7 +154,9 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
           IconComponent={IconBalloon}
           description={
             <Stack>
-              <Text>Judged all {nHeadToHeads.toLocaleString()} head-to-head matchups between selected models</Text>
+              <Text>
+                Judged all {nHeadToHeads.toLocaleString()} head-to-head matchups between {modelNames}
+              </Text>
               <Button onClick={() => navigate(`/project/${projectSlug}`)}>View Leaderboard</Button>
             </Stack>
           }

--- a/ui/src/hooks/useModel.ts
+++ b/ui/src/hooks/useModel.ts
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+import { useModels } from './useModels.ts';
+
+export function useModel(projectSlug?: string, modelId?: number) {
+  const { data: models, ...query } = useModels(projectSlug);
+  const model = useMemo(() => (models ?? []).find(({ id }) => id === modelId), [models, modelId]);
+  return { data: model, ...query };
+}


### PR DESCRIPTION
Filter the displayed head-to-heads by voting status:

<img width="1139" alt="Screenshot 2024-09-13 at 1 31 23 PM" src="https://github.com/user-attachments/assets/fcbb744c-7079-4170-b154-ef86d51120b3">

Useful for:

- Providing your own human ratings on only head-to-heads that don't already have them
- Reviewing ratings submitted by judges on a subset of all head-to-heads