### PR TITLE
Save head-to-head votes while auto judge task is in progress

### DIFF
--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -1,7 +1,7 @@
 import dataclasses
 from datetime import datetime
 from enum import Enum
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 from pydantic.dataclasses import dataclass
 
@@ -53,7 +53,7 @@ class HeadToHeadsRequest:
     model_b_id: Optional[int] = None  # when empty, get all pairings
 
 
-WinnerType = Literal["A", "B", "-"]
+WinnerType = Union[Literal["A", "B", "-"], str]  # should be one of the literal values, but could be anything
 
 
 @dataclass(frozen=True)

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -63,7 +63,7 @@ def router() -> APIRouter:
             ModelService.upload_responses(project_slug, model_name, df_response)
             for model_name, df_response in df_response_by_model_name.items()
         ]
-        background_tasks.add_task(TaskService.auto_judge_by_models, project_slug, new_models)
+        background_tasks.add_task(TaskService.auto_judge, project_slug, models=new_models)
         return new_models
 
     @r.get("/project/{project_slug}/model/{model_id}/responses")
@@ -74,7 +74,7 @@ def router() -> APIRouter:
     @r.post("/project/{project_slug}/model/{model_id}/judge")
     def trigger_model_auto_judge(project_slug: str, model_id: int, background_tasks: BackgroundTasks) -> None:
         model = ModelService.get_by_id(project_slug, model_id)
-        background_tasks.add_task(TaskService.auto_judge_by_models, project_slug, [model])
+        background_tasks.add_task(TaskService.auto_judge, project_slug, models=[model])
 
     @r.delete("/project/{project_slug}/model/{model_id}")
     def delete_model(project_slug: str, model_id: int, background_tasks: BackgroundTasks) -> None:
@@ -144,8 +144,8 @@ def router() -> APIRouter:
         background_tasks: BackgroundTasks,
     ) -> None:
         judges = [j for j in JudgeService.get_all(project_slug) if j.id in set(request.judge_ids)]
-        kwargs = dict(fraction=request.fraction, skip_existing=request.skip_existing)
-        background_tasks.add_task(TaskService.auto_judge_by_judges, project_slug, judges, **kwargs)
+        kwargs = dict(judges=judges, fraction=request.fraction, skip_existing=request.skip_existing)
+        background_tasks.add_task(TaskService.auto_judge, project_slug, **kwargs)
 
     @r.get("/project/{project_slug}/judges")
     def get_judges(project_slug: str) -> list[api.Judge]:

--- a/autoarena/judge/anthropic.py
+++ b/autoarena/judge/anthropic.py
@@ -30,7 +30,5 @@ class AnthropicJudge(AutomatedJudge):
             messages=[dict(role="user", content=get_user_prompt(prompt, response_a, response_b))],
             max_tokens=self.MAX_TOKENS,
         )
-        self.n_calls += 1
-        self.total_input_tokens += response.usage.input_tokens
-        self.total_output_tokens += response.usage.output_tokens
+        self.update_usage(response.usage.input_tokens, response.usage.output_tokens)
         return response.content[0].text

--- a/autoarena/judge/base.py
+++ b/autoarena/judge/base.py
@@ -12,14 +12,14 @@ class AutomatedJudge(metaclass=ABCMeta):
     _model_name: str
     _system_prompt: str
 
-    n_calls: int
+    n_requests: int
     total_input_tokens: int
     total_output_tokens: int
 
     def __init__(self, model_name: str, system_prompt: str):
         self._model_name = model_name
         self._system_prompt = system_prompt
-        self.n_calls = 0
+        self.n_requests = 0
         self.total_input_tokens = 0
         self.total_output_tokens = 0
         key = os.environ.get(self.API_KEY_NAME, None) if self.API_KEY_NAME is not None else None
@@ -51,12 +51,12 @@ class AutomatedJudge(metaclass=ABCMeta):
         """
 
     def update_usage(self, input_tokens: int, output_tokens: int) -> None:
-        self.n_calls += 1
+        self.n_requests += 1
         self.total_input_tokens += input_tokens
         self.total_output_tokens += output_tokens
 
     def log_usage(self) -> None:
         logger.info(
             f"'{self.name}' used {self.total_input_tokens} input tokens and {self.total_output_tokens} output tokens "
-            f"over {self.n_calls} calls",
+            f"over {self.n_requests} requests",
         )

--- a/autoarena/judge/base.py
+++ b/autoarena/judge/base.py
@@ -2,8 +2,6 @@ import os
 from abc import abstractmethod, ABCMeta
 from typing import Optional
 
-from loguru import logger
-
 
 class AutomatedJudge(metaclass=ABCMeta):
     API_KEY_NAME: Optional[str] = None  # if set, verify that this exists in environment on init
@@ -55,8 +53,8 @@ class AutomatedJudge(metaclass=ABCMeta):
         self.total_input_tokens += input_tokens
         self.total_output_tokens += output_tokens
 
-    def log_usage(self) -> None:
-        logger.info(
+    def get_usage_summary(self) -> str:
+        return (
             f"'{self.name}' used {self.total_input_tokens} input tokens and {self.total_output_tokens} output tokens "
-            f"over {self.n_requests} requests",
+            f"over {self.n_requests} requests"
         )

--- a/autoarena/judge/base.py
+++ b/autoarena/judge/base.py
@@ -50,6 +50,11 @@ class AutomatedJudge(metaclass=ABCMeta):
         interact with this judge. Throw an exception if not.
         """
 
+    def update_usage(self, input_tokens: int, output_tokens: int) -> None:
+        self.n_calls += 1
+        self.total_input_tokens += input_tokens
+        self.total_output_tokens += output_tokens
+
     def log_usage(self) -> None:
         logger.info(
             f"'{self.name}' used {self.total_input_tokens} input tokens and {self.total_output_tokens} output tokens "

--- a/autoarena/judge/bedrock.py
+++ b/autoarena/judge/bedrock.py
@@ -23,7 +23,5 @@ class BedrockJudge(AutomatedJudge):
             messages=[dict(role="user", content=[dict(text=get_user_prompt(prompt, response_a, response_b))])],
             inferenceConfig=dict(maxTokens=self.MAX_TOKENS),
         )
-        self.n_calls += 1
-        self.total_input_tokens += response["usage"]["inputTokens"]
-        self.total_output_tokens += response["usage"]["outputTokens"]
+        self.update_usage(response["usage"]["inputTokens"], response["usage"]["outputTokens"])
         return response["output"]["message"]["content"][0]["text"]

--- a/autoarena/judge/cohere.py
+++ b/autoarena/judge/cohere.py
@@ -23,7 +23,5 @@ class CohereJudge(AutomatedJudge):
             message=get_user_prompt(prompt, response_a, response_b),
             max_tokens=self.MAX_TOKENS,
         )
-        self.n_calls += 1
-        self.total_input_tokens += int(response.meta.billed_units.input_tokens)
-        self.total_output_tokens += int(response.meta.billed_units.output_tokens)
+        self.update_usage(int(response.meta.billed_units.input_tokens), int(response.meta.billed_units.output_tokens))
         return response.text

--- a/autoarena/judge/custom.py
+++ b/autoarena/judge/custom.py
@@ -1,0 +1,19 @@
+from autoarena.judge.base import AutomatedJudge
+
+_CUSTOM_JUDGE_NAME_TO_CLASS: dict[str, type[AutomatedJudge]] = {}
+
+
+def register_custom_judge_class(custom_judge_name: str, custom_judge_class: type[AutomatedJudge]) -> None:
+    global _CUSTOM_JUDGE_NAME_TO_CLASS
+    _CUSTOM_JUDGE_NAME_TO_CLASS[custom_judge_name] = custom_judge_class
+
+
+def get_custom_judge_class(custom_judge_name: str) -> type[AutomatedJudge]:
+    if custom_judge_name not in _CUSTOM_JUDGE_NAME_TO_CLASS:
+        raise ValueError(f"No implementation for custom judge with name '{custom_judge_name}'")
+    return _CUSTOM_JUDGE_NAME_TO_CLASS[custom_judge_name]
+
+
+def clear_custom_judge_classes() -> None:
+    global _CUSTOM_JUDGE_NAME_TO_CLASS
+    _CUSTOM_JUDGE_NAME_TO_CLASS.clear()

--- a/autoarena/judge/gemini.py
+++ b/autoarena/judge/gemini.py
@@ -1,6 +1,7 @@
 import os
 
 import google.generativeai as genai
+from loguru import logger
 
 from autoarena.judge.base import AutomatedJudge
 from autoarena.judge.utils import get_user_prompt, JOINED_PROMPT_TEMPLATE, rate_limit
@@ -36,4 +37,8 @@ class GeminiJudge(AutomatedJudge):
             },
         )
         self.update_usage(response.usage_metadata.prompt_token_count, response.usage_metadata.candidates_token_count)
+        if response.prompt_feedback.block_reason != 0:
+            message = f"Prompt blocked by '{self.name}' safety filters: {response.prompt_feedback}. Recording as '-'"
+            logger.warning(message)
+            return "-"
         return response.text

--- a/autoarena/judge/gemini.py
+++ b/autoarena/judge/gemini.py
@@ -35,7 +35,5 @@ class GeminiJudge(AutomatedJudge):
                 genai.types.HarmCategory.HARM_CATEGORY_HARASSMENT: genai.types.HarmBlockThreshold.BLOCK_NONE,
             },
         )
-        self.n_calls += 1
-        self.total_input_tokens += response.usage_metadata.prompt_token_count
-        self.total_output_tokens += response.usage_metadata.candidates_token_count
+        self.update_usage(response.usage_metadata.prompt_token_count, response.usage_metadata.candidates_token_count)
         return response.text

--- a/autoarena/judge/ollama.py
+++ b/autoarena/judge/ollama.py
@@ -34,7 +34,5 @@ class OllamaJudge(AutomatedJudge):
             ],
             options=dict(temperature=0, seed=0, num_predict=self.MAX_TOKENS),
         )
-        self.n_calls += 1
-        self.total_input_tokens += response["prompt_eval_count"]
-        self.total_output_tokens += response["eval_count"]
+        self.update_usage(response["prompt_eval_count"], response["eval_count"])
         return response["message"]["content"]

--- a/autoarena/judge/openai.py
+++ b/autoarena/judge/openai.py
@@ -33,9 +33,7 @@ class OpenAIJudge(AutomatedJudge):
             timeout=httpx.Timeout(30),  # time out in 30 seconds
         )
         response = response_raw.parse()
-        self.n_calls += 1
-        self.total_input_tokens += response.usage.prompt_tokens
-        self.total_output_tokens += response.usage.completion_tokens
+        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
         self._handle_rate_limit(dict(response_raw.headers))
         return response.choices[0].message.content
 

--- a/autoarena/judge/together.py
+++ b/autoarena/judge/together.py
@@ -25,7 +25,5 @@ class TogetherJudge(AutomatedJudge):
             ],
             max_tokens=self.MAX_TOKENS,
         )
-        self.n_calls += 1
-        self.total_input_tokens += response.usage.prompt_tokens
-        self.total_output_tokens += response.usage.completion_tokens
+        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
         return response.choices[0].message.content

--- a/autoarena/judge/wrapper.py
+++ b/autoarena/judge/wrapper.py
@@ -73,7 +73,7 @@ def fixing_wrapper(judge_class: type[T]) -> type[T]:
             if winner not in ACCEPTABLE_RESPONSES:
                 classifications = self.pipe(winner_raw, candidate_labels=self.CLASSES)
                 winner = self.CLASS_TO_WINNER[classifications["labels"][0]]
-                logger.warning(f"Fixed bad response: '{winner_raw}' as '{winner}'")
+                logger.warning(f"Fixed bad response from '{self.name}': '{winner_raw}' as '{winner}'")
             return winner
 
     return FixingJudge

--- a/autoarena/service/elo.py
+++ b/autoarena/service/elo.py
@@ -1,11 +1,11 @@
 import time
 from collections import defaultdict
-from typing import Literal
 
 import pandas as pd
 from pydantic.dataclasses import dataclass
 from loguru import logger
 
+from autoarena.api import api
 from autoarena.service.project import ProjectService
 
 
@@ -15,6 +15,7 @@ class EloConfig:
     k: int = 4
     scale: int = 400
     base: int = 10
+    n_bootstrap_rounds: int = 200
 
 
 DEFAULT_ELO_CONFIG = EloConfig()
@@ -45,9 +46,9 @@ class EloService:
             ).df()
 
     @staticmethod
-    def reseed_scores(project_slug: str) -> None:
+    def reseed_scores(project_slug: str, config: EloConfig = DEFAULT_ELO_CONFIG) -> None:
         df_h2h = EloService.get_df_head_to_head(project_slug)
-        df_elo = EloService.compute_elo(df_h2h)  # noqa: F841
+        df_elo = EloService.compute_elo(df_h2h, config=config)  # noqa: F841
         with ProjectService.connect(project_slug) as conn:
             conn.execute(  # reset all scores before updating new ones
                 "UPDATE model SET elo = $default_elo, q025 = NULL, q975 = NULL",
@@ -70,7 +71,7 @@ class EloService:
     def compute_elo_single(
         elo_a: float,
         elo_b: float,
-        winner: Literal["A", "B", "-"],
+        winner: api.WinnerType,
         config: EloConfig = DEFAULT_ELO_CONFIG,
     ) -> tuple[float, float]:
         expected_a = 1 / (1 + config.base ** ((elo_b - elo_a) / config.scale))
@@ -83,17 +84,7 @@ class EloService:
     @staticmethod
     def compute_elo(df_h2h: pd.DataFrame, *, config: EloConfig = DEFAULT_ELO_CONFIG) -> pd.DataFrame:
         df_elo = EloService._compute_elo_once(df_h2h, config=config)
-        df_elo = EloService._compute_confidence_intervals(df_elo, df_h2h, config=config)
-        return df_elo
-
-    @staticmethod
-    def _compute_confidence_intervals(
-        df_elo: pd.DataFrame,
-        df_h2h: pd.DataFrame,
-        *,
-        config: EloConfig = DEFAULT_ELO_CONFIG,
-    ) -> pd.DataFrame:
-        df_bootstrap = EloService._get_bootstrap_result(df_h2h, num_rounds=200, config=config)
+        df_bootstrap = EloService._get_bootstrap_result(df_h2h, config=config)
         # set Elo score to the median of the bootstrap result -- the order of the head-to-heads doesn't matter for bulk
         #  judging so the "true" score is in the middle of the differently ordered rollouts
         df_elo = df_elo.merge(df_bootstrap.quantile(0.5).rename("elo_median"), left_on="model", right_index=True)
@@ -114,16 +105,11 @@ class EloService:
         return df_elo.sort_values(by="elo", ascending=False)
 
     @staticmethod
-    def _get_bootstrap_result(
-        df_h2h: pd.DataFrame,
-        *,
-        num_rounds: int = 1_000,
-        config: EloConfig = DEFAULT_ELO_CONFIG,
-    ) -> pd.DataFrame:
+    def _get_bootstrap_result(df_h2h: pd.DataFrame, *, config: EloConfig = DEFAULT_ELO_CONFIG) -> pd.DataFrame:
         rows = []
         t_start = time.time()
-        logger.info(f"Bootstrapping confidence intervals with {num_rounds} rounds...")
-        for _ in range(num_rounds):
+        logger.info(f"Bootstrapping confidence intervals with {config.n_bootstrap_rounds} rounds...")
+        for _ in range(config.n_bootstrap_rounds):
             df_h2h_tmp = df_h2h.sample(frac=1.0, replace=True)
             rows.append(EloService._compute_elo_once(df_h2h_tmp, config=config))
         logger.info(f"Bootstrapped confidence intervals in {time.time() - t_start:0.1f} seconds")

--- a/autoarena/service/fine_tuning.py
+++ b/autoarena/service/fine_tuning.py
@@ -8,5 +8,5 @@ class FineTuningService:
     def create_task(project_slug: str, request: api.CreateFineTuningTaskRequest) -> None:
         # 1. kick off fine-tuning job
         # 2. create judge when complete
-        api_task = TaskService.create(project_slug, api.TaskType.FINE_TUNE)
-        TaskService.Task(project_slug, api_task).update(f"Fine-tuning '{request.base_model}' base model", progress=0.1)
+        task_id = TaskService.create(project_slug, api.TaskType.FINE_TUNE).id
+        TaskService.update(project_slug, task_id, f"Fine-tuning '{request.base_model}' base model", progress=0.1)

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -100,4 +100,4 @@ class ProjectService:
         tasks = TaskService.get_all(slug)
         for task in tasks:
             if task.status not in {api.TaskStatus.COMPLETED, api.TaskStatus.FAILED}:
-                TaskService.Task(slug, task).update("Terminated", status=api.TaskStatus.FAILED)
+                TaskService.update(slug, task.id, "Terminated", status=api.TaskStatus.FAILED)

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -1,3 +1,4 @@
+import dataclasses
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -5,13 +6,13 @@ from typing import Optional
 
 import pandas as pd
 from loguru import logger
+from pydantic.dataclasses import dataclass
 
 from autoarena.api import api
-from autoarena.api.api import JudgeType
 from autoarena.judge.base import AutomatedJudge
 from autoarena.judge.executor import ThreadedExecutor, JudgeExecutor
 from autoarena.judge.factory import judge_factory
-from autoarena.judge.wrapper import ab_shuffling_wrapper, fixing_wrapper, retrying_wrapper
+from autoarena.judge.wrapper import ab_shuffling_wrapper, fixing_wrapper, retrying_wrapper, JudgeWrapper
 from autoarena.service.elo import EloService
 from autoarena.service.head_to_head import HeadToHeadService
 from autoarena.service.judge import JudgeService
@@ -47,6 +48,27 @@ class TaskService:
             conn.execute("TRUNCATE task")
 
     @staticmethod
+    def update(
+        project_slug: str,
+        task_id: int,
+        log: str,
+        progress: Optional[float] = None,
+        status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
+    ) -> None:
+        with ProjectService.connect(project_slug) as conn:
+            log = f"{TaskService._time_slug()} {log}"
+            conn.execute(
+                """
+                UPDATE task
+                SET progress = IFNULL($progress, progress),
+                    status = $status,
+                    logs = logs || '\n' || $log
+                WHERE id = $id
+                """,
+                dict(id=task_id, log=log, progress=progress, status=status.value),
+            )
+
+    @staticmethod
     def _time_slug() -> str:
         return datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
 
@@ -56,186 +78,168 @@ class TaskService:
         task_objects = TaskService.get_all(project_slug)
         if len([t for t in task_objects if t.task_type is api.TaskType.RECOMPUTE_LEADERBOARD and t.progress < 1]) > 0:
             return  # only recompute if there isn't already a task in progress
-        api_task = TaskService.create(project_slug, api.TaskType.RECOMPUTE_LEADERBOARD)
-        task = TaskService.Task(project_slug, api_task)
+        task_id = TaskService.create(project_slug, api.TaskType.RECOMPUTE_LEADERBOARD).id
         try:
             EloService.reseed_scores(project_slug)
         finally:
-            task.update("Done", progress=1, status=api.TaskStatus.COMPLETED)
+            TaskService.update(project_slug, task_id, "Done", progress=1, status=api.TaskStatus.COMPLETED)
 
     @staticmethod
-    def auto_judge_by_judges(
+    def auto_judge(
         project_slug: str,
-        judges: list[api.Judge],
         *,
+        models: Optional[list[api.Model]] = None,
+        judges: Optional[list[api.Judge]] = None,
         fraction: float = 1.0,
         skip_existing: bool = False,
     ) -> None:
-        judge_names = ", ".join([f"'{judge.name}'" for judge in judges])
-        message = f"Started automated judging task for {judge_names}"
-        models = ModelService.get_all(project_slug)
-        api_task = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message)
-        task = TaskService.Task(project_slug, api_task)
-        with ThreadedExecutor(8) as executor:
-            TaskService._auto_judge_inner(
-                project_slug, task, models, judges, executor, fraction=fraction, skip_existing=skip_existing
-            )
-
-    @staticmethod
-    def auto_judge_by_models(
-        project_slug: str,
-        models: list[api.Model],
-        *,
-        fraction: float = 1.0,
-        skip_existing: bool = False,
-    ) -> None:
-        model_names = ", ".join([f"'{m.name}'" for m in models])
-        all_judges = JudgeService.get_all(project_slug)
-        enabled_judges = [j for j in all_judges if j.enabled and j.judge_type is not JudgeType.HUMAN]
-        if len(enabled_judges) == 0:
-            logger.warning(f"No automated judges found, can't run automated judgement for {model_names}")
-            return  # do nothing if no judges are configured, do not create a task
-        message = f"Started automated judging task for {model_names}"
-        api_task = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message)
-        task = TaskService.Task(project_slug, api_task)
-        logger.info(message)
-        with ThreadedExecutor(8) as executor:
-            TaskService._auto_judge_inner(
-                project_slug, task, models, enabled_judges, executor, fraction=fraction, skip_existing=skip_existing
-            )
-
-    @staticmethod
-    def _auto_judge_inner(
-        project_slug: str,
-        task: "TaskService.Task",
-        models: list[api.Model],
-        judges: list[api.Judge],
-        executor: JudgeExecutor,
-        *,
-        fraction: float = 1.0,
-        skip_existing: bool = False,
-    ) -> None:
-        t_start = time.time()
+        auto_judge_task = AutoJudgeTask.create(project_slug, models, judges, fraction, skip_existing)
+        if auto_judge_task is None:
+            return
         try:
-            # 1. instantiate judge(s)
-            task.update(f"Using {len(judges)} judge(s):")
-            for j in judges:
-                task.update(f"  * {j.name}")
-            wrappers = [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
-            automated_judges = [judge_factory(j, wrappers=wrappers) for j in judges]
-
-            # 2. get pairs eligible for judging
-            df_h2hs = [HeadToHeadService.get_df(project_slug, api.HeadToHeadsRequest(model_a_id=m.id)) for m in models]
-            df_h2h = pd.concat(df_h2hs)
-            if len(df_h2h) == 0:
-                message = "No head-to-heads found, exiting"
-                logger.warning(message)
-                task.update(message, status=api.TaskStatus.COMPLETED, progress=1)
-                return
-            df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
-            df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
-
-            n_models = len(set(df_h2h.model_a_id) | set(df_h2h.model_b_id))
-            task.update(f"Found {len(df_h2h)} total head-to-heads between {n_models} model(s) to judge")
-
-            if fraction < 1:
-                n_total = len(df_h2h)
-                df_h2h = df_h2h.sample(frac=fraction)
-                task.update(f"Using subset of {len(df_h2h)} out of {n_total} head-to-heads ({int(100 * fraction)}%)")
-
-            # 3. stream judgement requests
-            judges_with_h2hs: list[tuple[AutomatedJudge, list[api.HeadToHead]]] = []
-            for judge in automated_judges:
-                head_to_heads = [
-                    api.HeadToHead(r.prompt, r.response_a_id, r.response_a, r.response_b_id, r.response_b)
-                    for r in df_h2h.itertuples()
-                    if not skip_existing or judge.name not in {h["judge_name"] for h in r.history}
-                ]
-                if skip_existing:
-                    n_skipping = len(df_h2h) - len(head_to_heads)
-                    message = (
-                        f"Skipping {n_skipping} for '{judge.name}' with existing votes, {len(head_to_heads)} to run"
-                    )
-                    logger.info(message)
-                    task.update(message)
-                if len(head_to_heads) == 0:
-                    logger.warning(f"No head-to-heads without votes found for '{judge.name}', skipping this judge")
-                else:
-                    judges_with_h2hs.append((judge, head_to_heads))
-
-            if len(judges_with_h2hs) == 0:
-                message = "No head-to-heads without votes found for any judges, exiting"
-                logger.warning(message)
-                task.update(message, status=api.TaskStatus.COMPLETED, progress=1)
-                return
-
-            responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
-            n_h2h_by_judge_name = {judge.name: len(h2hs) for judge, h2hs in judges_with_h2hs}
-            n_total = sum(len(h2hs) for _, h2hs in judges_with_h2hs)
-            t_start_judging = time.time()
-            for judge, h2h, winner in executor.execute(judges_with_h2hs):
-                responses[judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
-                n_this_judge = len(responses[judge.name])
-                n_responses = sum(len(r) for r in responses.values())
-                progress = 0.95 * (n_responses / n_total)
-                if n_this_judge % 10 == 0:
-                    message = f"Judged {n_this_judge} of {n_h2h_by_judge_name[judge.name]} with '{judge.name}'"
-                    task.update(message, progress=progress)
-                if n_this_judge == n_h2h_by_judge_name[judge.name]:
-                    message = (
-                        f"Judge '{judge.name}' finished judging {n_h2h_by_judge_name[judge.name]} head-to-heads in "
-                        f"{time.time() - t_start_judging:0.1f} seconds"
-                    )
-                    task.update(message, progress=progress)
-                    judge.log_usage()
-
-            # TODO: stream to database?
-            # 4. upload judgements to database
-            judge_id_by_name = {j.name: j.id for j in judges}
-            dfs_h2h_judged = []
-            for judge_name, judge_responses in responses.items():
-                df_h2h_judged = df_h2h.copy()
-                df_h2h_judged["judge_id"] = judge_id_by_name[judge_name]
-                df_judgement = pd.DataFrame(judge_responses, columns=["response_a_id", "response_b_id", "winner"])
-                df_h2h_judged = pd.merge(df_h2h_judged, df_judgement, on=["response_a_id", "response_b_id"], how="left")
-                df_h2h_judged = df_h2h_judged.dropna(subset=["winner"])
-                dfs_h2h_judged.append(df_h2h_judged)
-            df_h2h_judged_all = pd.concat(dfs_h2h_judged)
-            HeadToHeadService.upload_head_to_heads(project_slug, df_h2h_judged_all)
-
-            # 6. recompute elo scores and confidence intervals
-            task.update("Recomputing leaderboard rankings", progress=0.96)
-            EloService.reseed_scores(project_slug)
-            message = f"Completed automated judging in {time.time() - t_start:0.1f} seconds"
-            task.update(message, progress=1, status=api.TaskStatus.COMPLETED)
-            logger.info(message)
+            with ThreadedExecutor(8) as executor:
+                auto_judge_task.run(executor)
         except Exception as e:
-            task.update(f"Failed ({e})", status=api.TaskStatus.FAILED)
+            TaskService.update(project_slug, auto_judge_task.task_id, f"Failed ({e})", status=api.TaskStatus.FAILED)
             message = "See AutoArena service logs for more information"
-            task.update(message, status=api.TaskStatus.FAILED)
+            TaskService.update(project_slug, auto_judge_task.task_id, message, status=api.TaskStatus.FAILED)
             logger.error(f"Automated judgement failed: {e}")
             raise e
 
-    class Task:
-        def __init__(self, project_slug: str, task: api.Task):
-            self._project_slug = project_slug
-            self._task = task
 
-        def update(
-            self,
-            log: str,
-            progress: Optional[float] = None,
-            status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
-        ) -> None:
-            with ProjectService.connect(self._project_slug) as conn:
-                log = f"{TaskService._time_slug()} {log}"
-                conn.execute(
-                    """
-                    UPDATE task
-                    SET progress = IFNULL($progress, progress),
-                        status = $status,
-                        logs = logs || '\n' || $log
-                    WHERE id = $id
-                    """,
-                    dict(id=self._task.id, log=log, progress=progress, status=status.value),
+@dataclass(frozen=True)
+class AutoJudgeTask:
+    project_slug: str
+    task_id: int
+    models: list[api.Model]
+    judges: list[api.Judge]
+    fraction: float = 1.0
+    skip_existing: bool = False
+    t_start: float = dataclasses.field(default_factory=time.time)
+    judge_wrappers: list[JudgeWrapper] = dataclasses.field(
+        default_factory=lambda: [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
+    )
+
+    def __post_init__(self) -> None:
+        if self.fraction <= 0 or self.fraction > 1:
+            raise ValueError(f"Invalid fraction: {self.fraction} must be on (0,1]")
+        if len(self.models) == 0:
+            raise ValueError("No models provided")
+        if len(self.judges) == 0:
+            raise ValueError("No judges provided")
+
+    @classmethod
+    def create(
+        cls,
+        project_slug: str,
+        models: Optional[list[api.Model]] = None,
+        judges: Optional[list[api.Judge]] = None,
+        fraction: float = 1.0,
+        skip_existing: bool = False,
+    ) -> Optional["AutoJudgeTask"]:
+        models = models or ModelService.get_all(project_slug)
+        judges = judges or JudgeService.get_all(project_slug)
+        enabled_judges = [j for j in judges if j.enabled and j.judge_type is not api.JudgeType.HUMAN]
+        if len(enabled_judges) == 0:
+            logger.warning("No enabled judges found, can't run automated judgement")
+            return None  # do nothing if no judges are configured, do not create a task
+        message = f"Started automated judging task using {len(enabled_judges)} judge(s)"
+        task_id = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message).id
+        logger.info(message)
+        return AutoJudgeTask(project_slug, task_id, models, enabled_judges, fraction, skip_existing)
+
+    def log(
+        self,
+        message: str,
+        status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
+        progress: Optional[float] = None,
+        level: str = "INFO",
+    ) -> None:
+        TaskService.update(self.project_slug, self.task_id, message, status=status, progress=progress)
+        logger.log(level, message)
+
+    # this is a beast, but most of the bulk comes from logging
+    def run(self, executor: JudgeExecutor) -> None:
+        h2h_requests = [api.HeadToHeadsRequest(model_a_id=m.id) for m in self.models]
+        df_h2h = pd.concat([HeadToHeadService.get_df(self.project_slug, request) for request in h2h_requests])
+        if len(df_h2h) == 0:
+            self.log("No head-to-heads found, exiting", status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
+            return
+
+        df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
+        df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
+        n_models = len(set(df_h2h.model_a_id) | set(df_h2h.model_b_id))
+        self.log(f"Found {len(df_h2h)} total head-to-heads between {n_models} model(s) to judge")
+
+        if self.fraction < 1:
+            n_total = len(df_h2h)
+            df_h2h = df_h2h.sample(frac=self.fraction)
+            self.log(f"Using subset of {len(df_h2h)} out of {n_total} head-to-heads ({int(100 * self.fraction)}%)")
+
+        # 2. instantiate judge(s)
+        self.log(f"Running {len(self.judges)} judge(s):")
+        for j in self.judges:
+            self.log(f"  * {j.name}")
+
+        # 3. assemble head-to-heads for judging
+        judges_with_h2hs: list[tuple[AutomatedJudge, list[api.HeadToHead]]] = []
+        for judge in self.judges:
+            automated_judge = judge_factory(judge, wrappers=self.judge_wrappers)
+            head_to_heads = [
+                api.HeadToHead(r.prompt, r.response_a_id, r.response_a, r.response_b_id, r.response_b)
+                for r in df_h2h.itertuples()
+                if not self.skip_existing or judge.name not in {h["judge_name"] for h in r.history}
+            ]
+            n_skipping = len(df_h2h) - len(head_to_heads)
+            if n_skipping > 0:
+                self.log(f"Skipping {n_skipping} for '{judge.name}' with existing votes, {len(head_to_heads)} to run")
+            if len(head_to_heads) == 0:
+                message = f"No head-to-heads without votes found for '{judge.name}', skipping this judge"
+                self.log(message, level="WARNING")
+            else:
+                judges_with_h2hs.append((automated_judge, head_to_heads))
+
+        if len(judges_with_h2hs) == 0:
+            message = "No head-to-heads without votes found for any judges, exiting"
+            self.log(message, status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
+            return
+
+        responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
+        n_h2h_by_judge_name = {judge.name: len(h2hs) for judge, h2hs in judges_with_h2hs}
+        n_total = sum(len(h2hs) for _, h2hs in judges_with_h2hs)
+        t_start_judging = time.time()
+        for auto_judge, h2h, winner in executor.execute(judges_with_h2hs):
+            responses[auto_judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
+            n_this_judge = len(responses[auto_judge.name])
+            n_responses = sum(len(r) for r in responses.values())
+            progress = 0.95 * (n_responses / n_total)
+            if n_this_judge % 10 == 0:
+                message = f"Judged {n_this_judge} of {n_h2h_by_judge_name[auto_judge.name]} with '{auto_judge.name}'"
+                self.log(message, progress=progress)
+            if n_this_judge == n_h2h_by_judge_name[auto_judge.name]:
+                message = (
+                    f"Judge '{auto_judge.name}' finished judging {n_h2h_by_judge_name[auto_judge.name]} head-to-heads "
+                    f"in {time.time() - t_start_judging:0.1f} seconds"
                 )
+                self.log(message, progress=progress)
+                auto_judge.log_usage()
+
+        # TODO: stream to database?
+        # 4. upload judgements to database
+        judge_id_by_name = {j.name: j.id for j in self.judges}
+        dfs_h2h_judged = []
+        for judge_name, judge_responses in responses.items():
+            df_h2h_judged = df_h2h.copy()
+            df_h2h_judged["judge_id"] = judge_id_by_name[judge_name]
+            df_judgement = pd.DataFrame(judge_responses, columns=["response_a_id", "response_b_id", "winner"])
+            df_h2h_judged = pd.merge(df_h2h_judged, df_judgement, on=["response_a_id", "response_b_id"], how="left")
+            df_h2h_judged = df_h2h_judged.dropna(subset=["winner"])
+            dfs_h2h_judged.append(df_h2h_judged)
+        df_h2h_judged_all = pd.concat(dfs_h2h_judged)
+        HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_judged_all)
+
+        # 6. recompute elo scores and confidence intervals
+        self.log("Recomputing leaderboard rankings", progress=0.975)
+        EloService.reseed_scores(self.project_slug)
+        message = f"Completed automated judging in {time.time() - self.t_start:0.1f} seconds"
+        self.log(message, progress=1, status=api.TaskStatus.COMPLETED, level="SUCCESS")

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -1,24 +1,10 @@
-import dataclasses
-import time
-from collections import defaultdict
 from datetime import datetime
 from typing import Optional
 
-import pandas as pd
-from loguru import logger
-from pydantic.dataclasses import dataclass
-
 from autoarena.api import api
-from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.executor import ThreadedExecutor, JudgeExecutor
-from autoarena.judge.factory import judge_factory
-from autoarena.judge.wrapper import ab_shuffling_wrapper, fixing_wrapper, retrying_wrapper, JudgeWrapper
+from autoarena.judge.executor import ThreadedExecutor
 from autoarena.service.elo import EloService
-from autoarena.service.head_to_head import HeadToHeadService
-from autoarena.service.judge import JudgeService
-from autoarena.service.model import ModelService
 from autoarena.service.project import ProjectService
-from autoarena.store.utils import id_slug
 
 
 class TaskService:
@@ -93,153 +79,9 @@ class TaskService:
         fraction: float = 1.0,
         skip_existing: bool = False,
     ) -> None:
+        from autoarena.task.auto_judge import AutoJudgeTask
+
         auto_judge_task = AutoJudgeTask.create(project_slug, models, judges, fraction, skip_existing)
-        if auto_judge_task is None:
-            return
-        try:
+        if auto_judge_task is not None:
             with ThreadedExecutor(8) as executor:
                 auto_judge_task.run(executor)
-        except Exception as e:
-            TaskService.update(project_slug, auto_judge_task.task_id, f"Failed ({e})", status=api.TaskStatus.FAILED)
-            message = "See AutoArena service logs for more information"
-            TaskService.update(project_slug, auto_judge_task.task_id, message, status=api.TaskStatus.FAILED)
-            logger.error(f"Automated judgement failed: {e}")
-            raise e
-
-
-@dataclass(frozen=True)
-class AutoJudgeTask:
-    project_slug: str
-    task_id: int
-    models: list[api.Model]
-    judges: list[api.Judge]
-    fraction: float = 1.0
-    skip_existing: bool = False
-    t_start: float = dataclasses.field(default_factory=time.time)
-    judge_wrappers: list[JudgeWrapper] = dataclasses.field(
-        default_factory=lambda: [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
-    )
-
-    def __post_init__(self) -> None:
-        if self.fraction <= 0 or self.fraction > 1:
-            raise ValueError(f"Invalid fraction: {self.fraction} must be on (0,1]")
-        if len(self.models) == 0:
-            raise ValueError("No models provided")
-        if len(self.judges) == 0:
-            raise ValueError("No judges provided")
-
-    @classmethod
-    def create(
-        cls,
-        project_slug: str,
-        models: Optional[list[api.Model]] = None,
-        judges: Optional[list[api.Judge]] = None,
-        fraction: float = 1.0,
-        skip_existing: bool = False,
-    ) -> Optional["AutoJudgeTask"]:
-        models = models or ModelService.get_all(project_slug)
-        judges = judges or JudgeService.get_all(project_slug)
-        enabled_judges = [j for j in judges if j.enabled and j.judge_type is not api.JudgeType.HUMAN]
-        if len(enabled_judges) == 0:
-            logger.warning("No enabled judges found, can't run automated judgement")
-            return None  # do nothing if no judges are configured, do not create a task
-        message = f"Started automated judging task using {len(enabled_judges)} judge(s)"
-        task_id = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message).id
-        logger.info(message)
-        return AutoJudgeTask(project_slug, task_id, models, enabled_judges, fraction, skip_existing)
-
-    def log(
-        self,
-        message: str,
-        status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
-        progress: Optional[float] = None,
-        level: str = "INFO",
-    ) -> None:
-        TaskService.update(self.project_slug, self.task_id, message, status=status, progress=progress)
-        logger.log(level, message)
-
-    # this is a beast, but most of the bulk comes from logging
-    def run(self, executor: JudgeExecutor) -> None:
-        h2h_requests = [api.HeadToHeadsRequest(model_a_id=m.id) for m in self.models]
-        df_h2h = pd.concat([HeadToHeadService.get_df(self.project_slug, request) for request in h2h_requests])
-        if len(df_h2h) == 0:
-            self.log("No head-to-heads found, exiting", status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
-            return
-
-        df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
-        df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
-        n_models = len(set(df_h2h.model_a_id) | set(df_h2h.model_b_id))
-        self.log(f"Found {len(df_h2h)} total head-to-heads between {n_models} model(s) to judge")
-
-        if self.fraction < 1:
-            n_total = len(df_h2h)
-            df_h2h = df_h2h.sample(frac=self.fraction)
-            self.log(f"Using subset of {len(df_h2h)} out of {n_total} head-to-heads ({int(100 * self.fraction)}%)")
-
-        # 2. instantiate judge(s)
-        self.log(f"Running {len(self.judges)} judge(s):")
-        for j in self.judges:
-            self.log(f"  * {j.name}")
-
-        # 3. assemble head-to-heads for judging
-        judges_with_h2hs: list[tuple[AutomatedJudge, list[api.HeadToHead]]] = []
-        for judge in self.judges:
-            automated_judge = judge_factory(judge, wrappers=self.judge_wrappers)
-            head_to_heads = [
-                api.HeadToHead(r.prompt, r.response_a_id, r.response_a, r.response_b_id, r.response_b)
-                for r in df_h2h.itertuples()
-                if not self.skip_existing or judge.name not in {h["judge_name"] for h in r.history}
-            ]
-            n_skipping = len(df_h2h) - len(head_to_heads)
-            if n_skipping > 0:
-                self.log(f"Skipping {n_skipping} for '{judge.name}' with existing votes, {len(head_to_heads)} to run")
-            if len(head_to_heads) == 0:
-                message = f"No head-to-heads without votes found for '{judge.name}', skipping this judge"
-                self.log(message, level="WARNING")
-            else:
-                judges_with_h2hs.append((automated_judge, head_to_heads))
-
-        if len(judges_with_h2hs) == 0:
-            message = "No head-to-heads without votes found for any judges, exiting"
-            self.log(message, status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
-            return
-
-        responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
-        n_h2h_by_judge_name = {judge.name: len(h2hs) for judge, h2hs in judges_with_h2hs}
-        n_total = sum(len(h2hs) for _, h2hs in judges_with_h2hs)
-        t_start_judging = time.time()
-        for auto_judge, h2h, winner in executor.execute(judges_with_h2hs):
-            responses[auto_judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
-            n_this_judge = len(responses[auto_judge.name])
-            n_responses = sum(len(r) for r in responses.values())
-            progress = 0.95 * (n_responses / n_total)
-            if n_this_judge % 10 == 0:
-                message = f"Judged {n_this_judge} of {n_h2h_by_judge_name[auto_judge.name]} with '{auto_judge.name}'"
-                self.log(message, progress=progress)
-            if n_this_judge == n_h2h_by_judge_name[auto_judge.name]:
-                message = (
-                    f"Judge '{auto_judge.name}' finished judging {n_h2h_by_judge_name[auto_judge.name]} head-to-heads "
-                    f"in {time.time() - t_start_judging:0.1f} seconds"
-                )
-                self.log(message, progress=progress)
-                auto_judge.log_usage()
-
-        # TODO: stream to database?
-        # 4. upload judgements to database
-        judge_id_by_name = {j.name: j.id for j in self.judges}
-        dfs_h2h_judged = []
-        for judge_name, judge_responses in responses.items():
-            df_h2h_judged = df_h2h.copy()
-            df_h2h_judged["judge_id"] = judge_id_by_name[judge_name]
-            df_judgement = pd.DataFrame(judge_responses, columns=["response_a_id", "response_b_id", "winner"])
-            df_h2h_judged = pd.merge(df_h2h_judged, df_judgement, on=["response_a_id", "response_b_id"], how="left")
-            df_h2h_judged = df_h2h_judged.dropna(subset=["winner"])
-            dfs_h2h_judged.append(df_h2h_judged)
-        df_h2h_judged_all = pd.concat(dfs_h2h_judged)
-        HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_judged_all)
-
-        # 6. recompute elo scores and confidence intervals
-        self.log("Recomputing leaderboard rankings", progress=0.975)
-        EloService.reseed_scores(self.project_slug)
-        message = f"Completed automated judging in {time.time() - self.t_start:0.1f} seconds"
-        self.log(message, progress=1, status=api.TaskStatus.COMPLETED, level="SUCCESS")

--- a/autoarena/task/auto_judge.py
+++ b/autoarena/task/auto_judge.py
@@ -1,0 +1,178 @@
+import dataclasses
+import time
+from collections import defaultdict
+from typing import Optional
+
+import pandas as pd
+from loguru import logger
+from pydantic.dataclasses import dataclass
+
+from autoarena.api import api
+from autoarena.judge.base import AutomatedJudge
+from autoarena.judge.executor import JudgeExecutor
+from autoarena.judge.factory import judge_factory
+from autoarena.judge.wrapper import JudgeWrapper, retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper
+from autoarena.service.elo import EloService, DEFAULT_ELO_CONFIG, EloConfig
+from autoarena.service.head_to_head import HeadToHeadService
+from autoarena.service.judge import JudgeService
+from autoarena.service.model import ModelService
+from autoarena.service.task import TaskService
+from autoarena.store.utils import id_slug
+
+
+class GracefulExit(RuntimeError): ...
+
+
+@dataclass(frozen=True)
+class AutoJudgeTask:
+    project_slug: str
+    task_id: int
+    models: list[api.Model]
+    judges: list[api.Judge]
+    fraction: float = 1.0
+    skip_existing: bool = False
+    t_start: float = dataclasses.field(default_factory=time.time)
+    judge_wrappers: list[JudgeWrapper] = dataclasses.field(
+        default_factory=lambda: [retrying_wrapper, fixing_wrapper, ab_shuffling_wrapper]
+    )
+    update_every: int = 10
+    elo_config: EloConfig = DEFAULT_ELO_CONFIG
+
+    def __post_init__(self) -> None:
+        if self.fraction <= 0 or self.fraction > 1:
+            raise ValueError(f"Invalid fraction: {self.fraction} must be on (0,1]")
+        if len(self.models) == 0:
+            raise ValueError("No models provided")
+        if len(self.judges) == 0:
+            raise ValueError("No judges provided")
+
+    @classmethod
+    def create(
+        cls,
+        project_slug: str,
+        models: Optional[list[api.Model]] = None,
+        judges: Optional[list[api.Judge]] = None,
+        fraction: float = 1.0,
+        skip_existing: bool = False,
+    ) -> Optional["AutoJudgeTask"]:
+        models = models if models is not None else ModelService.get_all(project_slug)
+        judges = judges if judges is not None else JudgeService.get_all(project_slug)
+        enabled_judges = [j for j in judges if j.enabled and j.judge_type is not api.JudgeType.HUMAN]
+        if len(enabled_judges) == 0:
+            logger.warning("No enabled judges found, can't run automated judgement")
+            return None  # do nothing if no judges are configured, do not create a task
+        message = f"Started automated judging task using {len(enabled_judges)} judge(s)"
+        task_id = TaskService.create(project_slug, api.TaskType.AUTO_JUDGE, message).id
+        logger.info(message)
+        return AutoJudgeTask(project_slug, task_id, models, enabled_judges, fraction, skip_existing)
+
+    def log(
+        self,
+        message: str,
+        status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
+        progress: Optional[float] = None,
+        level: str = "INFO",
+    ) -> None:
+        TaskService.update(self.project_slug, self.task_id, message, status=status, progress=progress)
+        logger.log(level, message)
+
+    # this is a beast, but most of the bulk comes from logging
+    def run(self, executor: JudgeExecutor) -> None:
+        try:
+            self._run_inner(executor)
+        except GracefulExit:
+            pass
+        except Exception as e:
+            TaskService.update(self.project_slug, self.task_id, f"Failed ({e})", status=api.TaskStatus.FAILED)
+            message = "See AutoArena service logs for more information"
+            TaskService.update(self.project_slug, self.task_id, message, status=api.TaskStatus.FAILED)
+            logger.error(f"Automated judgement failed: {e}")
+            raise e
+
+    def _retrieve_head_to_heads(self) -> pd.DataFrame:
+        h2h_requests = [api.HeadToHeadsRequest(model_a_id=m.id) for m in self.models]
+        df_h2h = pd.concat([HeadToHeadService.get_df(self.project_slug, request) for request in h2h_requests])
+        if len(df_h2h) == 0:
+            self.log("No head-to-heads found, exiting", status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
+            raise GracefulExit
+
+        df_h2h["response_id_slug"] = df_h2h.apply(lambda r: id_slug(r.response_a_id, r.response_b_id), axis=1)
+        df_h2h = df_h2h.drop_duplicates(subset=["response_id_slug"], keep="first")
+        n_models = len(set(df_h2h.model_a_id) | set(df_h2h.model_b_id))
+        self.log(f"Found {len(df_h2h)} total head-to-heads between {n_models} model(s) to judge")
+
+        if self.fraction < 1:
+            n_total = len(df_h2h)
+            df_h2h = df_h2h.sample(frac=self.fraction)
+            self.log(f"Using subset of {len(df_h2h)} out of {n_total} head-to-heads ({int(100 * self.fraction)}%)")
+
+        return df_h2h
+
+    def _instantiate_judges_with_head_to_heads(
+        self,
+        df_h2h: pd.DataFrame,
+    ) -> list[tuple[AutomatedJudge, list[api.HeadToHead]]]:
+        judges_with_h2hs: list[tuple[AutomatedJudge, list[api.HeadToHead]]] = []
+        for judge in self.judges:
+            automated_judge = judge_factory(judge, wrappers=self.judge_wrappers)
+            head_to_heads = [
+                api.HeadToHead(r.prompt, r.response_a_id, r.response_a, r.response_b_id, r.response_b)
+                for r in df_h2h.itertuples()
+                if not self.skip_existing or judge.name not in {h["judge_name"] for h in r.history}
+            ]
+            n_skipping = len(df_h2h) - len(head_to_heads)
+            if n_skipping > 0:
+                self.log(f"Skipping {n_skipping} for '{judge.name}' with existing votes, {len(head_to_heads)} to run")
+            if len(head_to_heads) == 0:
+                message = f"No head-to-heads without votes found for '{judge.name}', skipping this judge"
+                self.log(message, level="WARNING")
+            else:
+                judges_with_h2hs.append((automated_judge, head_to_heads))
+
+        if len(judges_with_h2hs) == 0:
+            message = "No head-to-heads without votes found for any judges, exiting"
+            self.log(message, status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")
+            raise GracefulExit
+
+        self.log(f"Running {len(judges_with_h2hs)} judge(s):")
+        for j, _ in judges_with_h2hs:
+            self.log(f"  * {j.name}")
+
+        return judges_with_h2hs
+
+    def _run_inner(self, executor: JudgeExecutor) -> None:
+        df_h2h = self._retrieve_head_to_heads()
+        judges_with_h2hs = self._instantiate_judges_with_head_to_heads(df_h2h)
+        judge_id_by_name = {j.name: j.id for j in self.judges}
+        out_columns = ["response_a_id", "response_b_id", "winner"]
+
+        responses: dict[str, list[tuple[int, int, str]]] = defaultdict(lambda: [])
+        n_h2h_by_judge_name = {judge.name: len(h2hs) for judge, h2hs in judges_with_h2hs}
+        n_total = sum(len(h2hs) for _, h2hs in judges_with_h2hs)
+        t_start_judging = time.time()
+        for auto_judge, h2h, winner in executor.execute(judges_with_h2hs):
+            responses[auto_judge.name].append((h2h.response_a_id, h2h.response_b_id, winner))
+            n_this_judge = len(responses[auto_judge.name])
+            n_responses = sum(len(r) for r in responses.values())
+            progress = 0.95 * (n_responses / n_total)
+            if n_this_judge % self.update_every == 0:
+                message = f"Judged {n_this_judge} of {n_h2h_by_judge_name[auto_judge.name]} with '{auto_judge.name}'"
+                self.log(message, progress=progress)
+                df_h2h_chunk = pd.DataFrame(responses[auto_judge.name][-self.update_every :], columns=out_columns)
+                df_h2h_chunk["judge_id"] = judge_id_by_name[auto_judge.name]
+                HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_chunk)
+            if n_this_judge == n_h2h_by_judge_name[auto_judge.name]:
+                message = (
+                    f"Judge '{auto_judge.name}' finished judging {n_h2h_by_judge_name[auto_judge.name]} head-to-heads "
+                    f"in {time.time() - t_start_judging:0.1f} seconds"
+                )
+                self.log(message, progress=progress)
+                self.log(auto_judge.get_usage_summary())
+                df_h2h_all = pd.DataFrame(responses[auto_judge.name], columns=out_columns)
+                df_h2h_all["judge_id"] = judge_id_by_name[auto_judge.name]
+                HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_all)
+
+        self.log("Recomputing leaderboard rankings", progress=0.975)
+        EloService.reseed_scores(self.project_slug, config=self.elo_config)
+        message = f"Completed automated judging in {time.time() - self.t_start:0.1f} seconds"
+        self.log(message, progress=1, status=api.TaskStatus.COMPLETED, level="SUCCESS")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "python-multipart",
     "loguru<1",
     "tenacity>=9,<10",
+    "pytimeparse>=1,<2",
     # TODO: these client libraries should be arranged into extras that are installed as needed
     "openai>=1,<2",
     "ollama<1",
@@ -53,7 +54,6 @@ dependencies = [
     "transformers>=4,<5",
     "torch>=2,<3",
     "together>=1,<2",
-    "pytimeparse>=1.1.8",
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -58,5 +58,10 @@ def model_c_id(project_client: TestClient) -> int:
 
 
 @pytest.fixture
+def model_ids(model_id: int, model_b_id: int, model_c_id: int) -> list[int]:
+    return [model_id, model_b_id, model_c_id]
+
+
+@pytest.fixture
 def judge_id(project_client: TestClient) -> int:
     return project_client.post("/judge", json=CREATE_JUDGE_REQUEST).json()["id"]

--- a/tests/integration/api/test_head_to_head.py
+++ b/tests/integration/api/test_head_to_head.py
@@ -57,10 +57,5 @@ def test__head_to_head__count__2_models(project_client: TestClient, model_id: in
     assert project_client.get("/head-to-head/count").json() == 2
 
 
-def test__head_to_head__count__3_models(
-    project_client: TestClient,
-    model_id: int,
-    model_b_id: int,
-    model_c_id: int,
-) -> None:
+def test__head_to_head__count__3_models(project_client: TestClient, model_ids: list[int]) -> None:
     assert project_client.get("/head-to-head/count").json() == 5

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,7 @@ import shutil
 import uuid
 from io import StringIO
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Callable
 
 import pytest
 from fastapi.testclient import TestClient
@@ -24,10 +24,15 @@ def test_data_directory() -> Iterator[Path]:
 
 
 @pytest.fixture(scope="function")
-def log_stream() -> Iterator[StringIO]:
+def log_stream() -> Iterator[Callable[[], str]]:
     logs = StringIO()
     logger.add(logs)
-    yield logs
+
+    def get() -> str:
+        logs.seek(0)
+        return logs.read()
+
+    yield get
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,12 @@
 import shutil
 import uuid
+from io import StringIO
 from pathlib import Path
 from typing import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
+from loguru import logger
 
 from autoarena.server import server, API_V1_STR
 from autoarena.store.database import set_data_directory
@@ -19,6 +21,13 @@ def test_data_directory() -> Iterator[Path]:
         yield data_directory
     finally:
         shutil.rmtree(data_directory, ignore_errors=True)
+
+
+@pytest.fixture(scope="function")
+def log_stream() -> Iterator[StringIO]:
+    logs = StringIO()
+    logger.add(logs)
+    yield logs
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/judge/test_judge.py
+++ b/tests/integration/judge/test_judge.py
@@ -22,6 +22,6 @@ def test__judge__automated(judge_type: api.JudgeType) -> None:
     model_name = TEST_JUDGE_MODEL_NAMES[judge_type]
     judge_instance = judge_factory(api_judge(judge_type, model_name), wrappers=[retrying_wrapper, cleaning_wrapper])
     assert judge_instance.judge("What is 2+2?", "4", "100 million") == "A"
-    assert judge_instance.n_calls == 1
+    assert judge_instance.n_requests == 1
     assert judge_instance.total_input_tokens > 0
     assert judge_instance.total_output_tokens > 0

--- a/ui/src/components/Judges/TriggerAutoJudgeModal.tsx
+++ b/ui/src/components/Judges/TriggerAutoJudgeModal.tsx
@@ -52,8 +52,8 @@ export function TriggerAutoJudgeModal({ judgeId, isOpen, onClose }: Props) {
   }
 
   function handleClose() {
-    form.reset();
     onClose();
+    form.reset();
   }
 
   // TODO: judgeIds doesn't seem to update always

--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -45,6 +45,7 @@ export function TaskAccordionItem({ task }: Props) {
       <Accordion.Panel>
         <Stack>
           <Progress
+            color={`${taskStatusToColor(task.status)}.2`}
             value={task.progress * 100}
             striped={!taskIsDone(task.status)}
             animated={!taskIsDone(task.status)}

--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -50,7 +50,16 @@ export function TaskAccordionItem({ task }: Props) {
             animated={!taskIsDone(task.status)}
           />
           <Code block fs="xs">
-            {task.logs}
+            {task.logs.split('\n').map((line, i) => (
+              <Text inherit key={i}>
+                <Text span inherit c="dimmed">
+                  {line.slice(0, 21)}
+                </Text>
+                <Text span inherit>
+                  {line.slice(21, line.length)}
+                </Text>
+              </Text>
+            ))}
           </Code>
         </Stack>
       </Accordion.Panel>

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -59,7 +59,7 @@ export function TasksDrawer() {
           closeCompletedTasks();
         }}
         position="right"
-        size="lg"
+        size="xl"
         transitionProps={{ duration: 200 }}
         title={
           <Text fs="italic" c="dimmed" size="sm">


### PR DESCRIPTION
- Add scaffolding to register custom judge implementations at runtime
- Refactor the auto judge task for maintainability
- Save head-to-head votes to database periodically, including adding retries to deal with DuckDB limitations