### PR TITLE
Changed head to head hotkeys

### DIFF
--- a/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
@@ -23,7 +23,7 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
   const response = useMemo(() => (modelResponses ?? [])?.[responseIndex], [modelResponses, responseIndex]);
   const nResponses = useMemo(() => (modelResponses ?? []).length, [modelResponses]);
 
-  function navigatePrevious() {
+  function navigateBack() {
     setResponseIndex(prev => Math.max(0, prev - 1));
   }
   function navigateNext() {
@@ -31,7 +31,7 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
   }
 
   useHotkeys([
-    ['ArrowLeft', navigatePrevious],
+    ['ArrowLeft', navigateBack],
     ['ArrowRight', navigateNext],
   ]);
 
@@ -58,12 +58,8 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
       <ControlBar ref={controlBarRef}>
         <Stack align="center" gap="xs">
           <SimpleGrid cols={2} spacing="xs">
-            <Button
-              leftSection={<IconArrowLeft {...iconProps} />}
-              onClick={navigatePrevious}
-              disabled={responseIndex < 1}
-            >
-              Previous
+            <Button leftSection={<IconArrowLeft {...iconProps} />} onClick={navigateBack} disabled={responseIndex < 1}>
+              Back
             </Button>
             <Button
               rightSection={<IconArrowRight {...iconProps} />}

--- a/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadSingleModel.tsx
@@ -1,5 +1,5 @@
 import { IconArrowLeft, IconArrowRight, IconCactus } from '@tabler/icons-react';
-import { Button, Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
+import { Button, Group, Kbd, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
 import { useMemo, useState } from 'react';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { pluralize } from '../../lib/string.ts';
@@ -33,6 +33,8 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
   useHotkeys([
     ['ArrowLeft', navigateBack],
     ['ArrowRight', navigateNext],
+    ['b', navigateBack],
+    ['n', navigateNext],
   ]);
 
   const modelName = model != null ? `'${model.name}'` : 'selected model';
@@ -58,16 +60,26 @@ export function HeadToHeadSingleModel({ modelId }: Props) {
       <ControlBar ref={controlBarRef}>
         <Stack align="center" gap="xs">
           <SimpleGrid cols={2} spacing="xs">
-            <Button leftSection={<IconArrowLeft {...iconProps} />} onClick={navigateBack} disabled={responseIndex < 1}>
-              Back
-            </Button>
-            <Button
-              rightSection={<IconArrowRight {...iconProps} />}
-              onClick={navigateNext}
-              disabled={responseIndex >= nResponses - 1}
-            >
-              Next
-            </Button>
+            <Group justify="space-between">
+              <Kbd>b</Kbd>
+              <Button
+                leftSection={<IconArrowLeft {...iconProps} />}
+                onClick={navigateBack}
+                disabled={responseIndex < 1}
+              >
+                Back
+              </Button>
+            </Group>
+            <Group justify="space-between">
+              <Button
+                rightSection={<IconArrowRight {...iconProps} />}
+                onClick={navigateNext}
+                disabled={responseIndex >= nResponses - 1}
+              >
+                Next
+              </Button>
+              <Kbd>n</Kbd>
+            </Group>
           </SimpleGrid>
         </Stack>
       </ControlBar>

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -180,7 +180,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
               <Text fw="bold">Which response is better?</Text>
               <SimpleGrid cols={5} spacing="xs">
                 <Button
-                  leftSection={<Kbd>p</Kbd>}
+                  leftSection={<Kbd>b</Kbd>}
                   variant="subtle"
                   color="gray"
                   onClick={navigateBack}

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -55,7 +55,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
     setHeadToHeadIndex(0);
   }, [modelAId, modelBId]);
 
-  function navigatePrevious() {
+  function navigateBack() {
     setHeadToHeadIndex(prev => Math.max(0, prev - 1));
   }
   function navigateNext() {
@@ -80,7 +80,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
     ['ArrowUp', submitVote('-')],
     ['ArrowDown', submitVote('-')],
     ['ArrowRight', submitVote('B')],
-    ['p', navigatePrevious],
+    ['b', navigateBack],
     ['n', navigateNext],
     ['h', toggleShowVoteHistory],
   ]);
@@ -183,11 +183,11 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
                   leftSection={<Kbd>p</Kbd>}
                   variant="subtle"
                   color="gray"
-                  onClick={navigatePrevious}
+                  onClick={navigateBack}
                   disabled={headToHeadIndex < 1}
                   h="100%"
                 >
-                  Previous
+                  Back
                 </Button>
                 <Button leftSection={<IconArrowLeft {...iconProps} />} onClick={submitVote('A')} h="100%">
                   Left is Better


### PR DESCRIPTION
The hotkeys for navigating between model results on the h2h page used to be `p` and `n` (previous and next).
Changing it to `b` and `n` (back and next) makes it slightly easier to use.