### PR TITLE
Report latency stats in judge implementations

### DIFF
--- a/autoarena/judge/anthropic.py
+++ b/autoarena/judge/anthropic.py
@@ -1,7 +1,7 @@
 import anthropic
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, rate_limit
+from autoarena.judge.utils import get_user_prompt, rate_limit, warn_if_slow
 
 
 class AnthropicJudge(AutomatedJudge):
@@ -23,6 +23,7 @@ class AnthropicJudge(AutomatedJudge):
 
     # anthropic has different tiers with 1000/2000/4000, opting to be conservative by default
     @rate_limit(n_calls=1_000, n_seconds=60)
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response = self._client.messages.create(
             model=self.model_name,

--- a/autoarena/judge/base.py
+++ b/autoarena/judge/base.py
@@ -62,7 +62,7 @@ class AutomatedJudge(metaclass=ABCMeta):
         self.total_output_tokens += output_tokens
         self.response_seconds.append(response_seconds)
         if response_seconds >= self.SLOW_THRESHOLD_SECONDS:
-            logger.warning(f"Slow response from {self.name}: {response_seconds:0.3f} seconds")
+            logger.warning(f"Slow response from '{self.name}': {response_seconds:0.3f} seconds")
 
     def get_usage_summary(self) -> list[str]:
         return [

--- a/autoarena/judge/base.py
+++ b/autoarena/judge/base.py
@@ -57,6 +57,7 @@ class AutomatedJudge(metaclass=ABCMeta):
         """
 
     def update_usage(self, input_tokens: int, output_tokens: int, response_seconds: float) -> None:
+        """Optionally call in `AutomatedJudge.judge` implementations to record usage metrics."""
         self.n_requests += 1
         self.total_input_tokens += input_tokens
         self.total_output_tokens += output_tokens
@@ -65,6 +66,8 @@ class AutomatedJudge(metaclass=ABCMeta):
             logger.warning(f"Slow response from '{self.name}': {response_seconds:0.3f} seconds")
 
     def get_usage_summary(self) -> list[str]:
+        if self.n_requests == 0 or len(self.response_seconds) == 0:
+            return [f"'{self.name}' has not recorded any usage"]
         return [
             f"'{self.name}' used {self.total_input_tokens} input tokens and {self.total_output_tokens} output tokens "
             f"over {self.n_requests} requests",

--- a/autoarena/judge/bedrock.py
+++ b/autoarena/judge/bedrock.py
@@ -1,7 +1,7 @@
 import boto3
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import rate_limit, get_user_prompt
+from autoarena.judge.utils import rate_limit, get_user_prompt, warn_if_slow
 
 
 class BedrockJudge(AutomatedJudge):
@@ -16,6 +16,7 @@ class BedrockJudge(AutomatedJudge):
         boto3.client(service_name="sts").get_caller_identity()
 
     @rate_limit(n_calls=200, n_seconds=1, n_call_buffer=25)
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response = self._client.converse(
             modelId=self.model_name,

--- a/autoarena/judge/cohere.py
+++ b/autoarena/judge/cohere.py
@@ -1,7 +1,7 @@
 import cohere
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, rate_limit
+from autoarena.judge.utils import get_user_prompt, rate_limit, warn_if_slow
 
 
 class CohereJudge(AutomatedJudge):
@@ -16,6 +16,7 @@ class CohereJudge(AutomatedJudge):
         cohere.Client().models.list()
 
     @rate_limit(n_calls=1_000, n_seconds=60)
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response = self._client.chat(
             model=self.model_name,

--- a/autoarena/judge/cohere.py
+++ b/autoarena/judge/cohere.py
@@ -1,7 +1,9 @@
+import time
+
 import cohere
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, rate_limit, warn_if_slow
+from autoarena.judge.utils import get_user_prompt, rate_limit
 
 
 class CohereJudge(AutomatedJudge):
@@ -16,13 +18,17 @@ class CohereJudge(AutomatedJudge):
         cohere.Client().models.list()
 
     @rate_limit(n_calls=1_000, n_seconds=60)
-    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
+        t0 = time.time()
         response = self._client.chat(
             model=self.model_name,
             preamble=self.system_prompt,
             message=get_user_prompt(prompt, response_a, response_b),
             max_tokens=self.MAX_TOKENS,
         )
-        self.update_usage(int(response.meta.billed_units.input_tokens), int(response.meta.billed_units.output_tokens))
+        self.update_usage(
+            int(response.meta.billed_units.input_tokens),
+            int(response.meta.billed_units.output_tokens),
+            time.time() - t0,
+        )
         return response.text

--- a/autoarena/judge/gemini.py
+++ b/autoarena/judge/gemini.py
@@ -3,7 +3,7 @@ import os
 import google.generativeai as genai
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, JOINED_PROMPT_TEMPLATE, rate_limit
+from autoarena.judge.utils import get_user_prompt, JOINED_PROMPT_TEMPLATE, rate_limit, warn_if_slow
 
 
 class GeminiJudge(AutomatedJudge):
@@ -21,6 +21,7 @@ class GeminiJudge(AutomatedJudge):
         list(genai.list_models(page_size=1))
 
     @rate_limit(n_calls=1_000, n_seconds=60)
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         user_prompt = get_user_prompt(prompt, response_a, response_b)
         full_prompt = JOINED_PROMPT_TEMPLATE.format(system_prompt=self.system_prompt, user_prompt=user_prompt)

--- a/autoarena/judge/gemini.py
+++ b/autoarena/judge/gemini.py
@@ -1,10 +1,11 @@
 import os
+import time
 
 import google.generativeai as genai
 from loguru import logger
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, JOINED_PROMPT_TEMPLATE, rate_limit, warn_if_slow
+from autoarena.judge.utils import get_user_prompt, JOINED_PROMPT_TEMPLATE, rate_limit
 
 
 class GeminiJudge(AutomatedJudge):
@@ -22,10 +23,10 @@ class GeminiJudge(AutomatedJudge):
         list(genai.list_models(page_size=1))
 
     @rate_limit(n_calls=1_000, n_seconds=60)
-    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         user_prompt = get_user_prompt(prompt, response_a, response_b)
         full_prompt = JOINED_PROMPT_TEMPLATE.format(system_prompt=self.system_prompt, user_prompt=user_prompt)
+        t0 = time.time()
         response = self._model.generate_content(
             full_prompt,
             generation_config=dict(max_output_tokens=self.MAX_TOKENS, temperature=0.0),
@@ -37,7 +38,11 @@ class GeminiJudge(AutomatedJudge):
                 genai.types.HarmCategory.HARM_CATEGORY_HARASSMENT: genai.types.HarmBlockThreshold.BLOCK_NONE,
             },
         )
-        self.update_usage(response.usage_metadata.prompt_token_count, response.usage_metadata.candidates_token_count)
+        self.update_usage(
+            response.usage_metadata.prompt_token_count,
+            response.usage_metadata.candidates_token_count,
+            time.time() - t0,
+        )
         if response.prompt_feedback.block_reason != 0:
             message = f"Prompt blocked by '{self.name}' safety filters: {response.prompt_feedback}. Recording as '-'"
             logger.warning(message)

--- a/autoarena/judge/ollama.py
+++ b/autoarena/judge/ollama.py
@@ -2,7 +2,7 @@ import httpx
 import ollama
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt
+from autoarena.judge.utils import get_user_prompt, warn_if_slow
 
 
 class OllamaJudge(AutomatedJudge):
@@ -25,6 +25,7 @@ class OllamaJudge(AutomatedJudge):
         except httpx.ConnectError:
             raise RuntimeError("Unable to connect to Ollama, ensure it is running on the same host running AutoArena")
 
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response = self._client.chat(
             model=self.model_name,

--- a/autoarena/judge/openai.py
+++ b/autoarena/judge/openai.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from pytimeparse.timeparse import timeparse
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, rate_limit
+from autoarena.judge.utils import get_user_prompt, rate_limit, warn_if_slow
 
 
 class OpenAIJudge(AutomatedJudge):
@@ -22,6 +22,7 @@ class OpenAIJudge(AutomatedJudge):
 
     # OpenAI has different tiers and different rate limits for different models, choose a safeish value
     @rate_limit(n_calls=1_000, n_seconds=60)
+    @warn_if_slow(slow_threshold_seconds=5)  # TODO: this will complain when handle_rate_limit self-throttles
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response_raw = self._client.chat.completions.with_raw_response.create(
             model=self.model_name,

--- a/autoarena/judge/openai.py
+++ b/autoarena/judge/openai.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from pytimeparse.timeparse import timeparse
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import get_user_prompt, rate_limit, warn_if_slow
+from autoarena.judge.utils import get_user_prompt, rate_limit
 
 
 class OpenAIJudge(AutomatedJudge):
@@ -22,8 +22,8 @@ class OpenAIJudge(AutomatedJudge):
 
     # OpenAI has different tiers and different rate limits for different models, choose a safeish value
     @rate_limit(n_calls=1_000, n_seconds=60)
-    @warn_if_slow(slow_threshold_seconds=5)  # TODO: this will complain when handle_rate_limit self-throttles
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
+        t0 = time.time()
         response_raw = self._client.chat.completions.with_raw_response.create(
             model=self.model_name,
             messages=[
@@ -34,7 +34,7 @@ class OpenAIJudge(AutomatedJudge):
             timeout=httpx.Timeout(30),  # time out in 30 seconds
         )
         response = response_raw.parse()
-        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
+        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens, time.time() - t0)
         self._handle_rate_limit(dict(response_raw.headers))
         return response.choices[0].message.content
 

--- a/autoarena/judge/together.py
+++ b/autoarena/judge/together.py
@@ -1,7 +1,9 @@
+import time
+
 import together
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import rate_limit, get_user_prompt, warn_if_slow
+from autoarena.judge.utils import rate_limit, get_user_prompt
 
 
 class TogetherJudge(AutomatedJudge):
@@ -16,8 +18,8 @@ class TogetherJudge(AutomatedJudge):
         together.Client().models.list()
 
     @rate_limit(n_calls=10, n_seconds=1, n_call_buffer=2)
-    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
+        t0 = time.time()
         response = self._client.chat.completions.create(
             model=self.model_name,
             messages=[
@@ -26,5 +28,5 @@ class TogetherJudge(AutomatedJudge):
             ],
             max_tokens=self.MAX_TOKENS,
         )
-        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
+        self.update_usage(response.usage.prompt_tokens, response.usage.completion_tokens, time.time() - t0)
         return response.choices[0].message.content

--- a/autoarena/judge/together.py
+++ b/autoarena/judge/together.py
@@ -1,7 +1,7 @@
 import together
 
 from autoarena.judge.base import AutomatedJudge
-from autoarena.judge.utils import rate_limit, get_user_prompt
+from autoarena.judge.utils import rate_limit, get_user_prompt, warn_if_slow
 
 
 class TogetherJudge(AutomatedJudge):
@@ -16,6 +16,7 @@ class TogetherJudge(AutomatedJudge):
         together.Client().models.list()
 
     @rate_limit(n_calls=10, n_seconds=1, n_call_buffer=2)
+    @warn_if_slow(slow_threshold_seconds=5)
     def judge(self, prompt: str, response_a: str, response_b: str) -> str:
         response = self._client.chat.completions.create(
             model=self.model_name,

--- a/autoarena/judge/utils.py
+++ b/autoarena/judge/utils.py
@@ -92,22 +92,3 @@ def rate_limit(
         return wrapper
 
     return decorator
-
-
-def warn_if_slow(*, slow_threshold_seconds: float = 10) -> Callable:
-    Params = ParamSpec("Params")
-    ReturnType = TypeVar("ReturnType")
-
-    def decorator(f: Callable[Params, ReturnType]) -> Callable[Params, ReturnType]:
-        @functools.wraps(f)
-        def wrapper(*args: Params.args, **kwargs: Params.kwargs) -> ReturnType:
-            t0 = time.time()
-            out = f(*args, **kwargs)
-            t1 = time.time()
-            if t1 - t0 >= slow_threshold_seconds:
-                logger.warning(f"Slow response from {f.__qualname__}: {t1 - t0:0.3f} seconds")
-            return out
-
-        return wrapper
-
-    return decorator

--- a/autoarena/judge/utils.py
+++ b/autoarena/judge/utils.py
@@ -92,3 +92,22 @@ def rate_limit(
         return wrapper
 
     return decorator
+
+
+def warn_if_slow(*, slow_threshold_seconds: float = 10) -> Callable:
+    Params = ParamSpec("Params")
+    ReturnType = TypeVar("ReturnType")
+
+    def decorator(f: Callable[Params, ReturnType]) -> Callable[Params, ReturnType]:
+        @functools.wraps(f)
+        def wrapper(*args: Params.args, **kwargs: Params.kwargs) -> ReturnType:
+            t0 = time.time()
+            out = f(*args, **kwargs)
+            t1 = time.time()
+            if t1 - t0 >= slow_threshold_seconds:
+                logger.warning(f"Slow response from {f.__qualname__}: {t1 - t0:0.3f} seconds")
+            return out
+
+        return wrapper
+
+    return decorator

--- a/autoarena/task/auto_judge.py
+++ b/autoarena/task/auto_judge.py
@@ -168,7 +168,8 @@ class AutoJudgeTask:
                     f"in {time.time() - t_start_judging:0.1f} seconds"
                 )
                 self.log(message, progress=progress)
-                self.log(auto_judge.get_usage_summary())
+                for usage_summary_line in auto_judge.get_usage_summary():
+                    self.log(usage_summary_line)
                 df_h2h_all = pd.DataFrame(responses[auto_judge.name], columns=out_columns)
                 self._try_write(lambda: HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_all))
 

--- a/tests/integration/judge/test_judge.py
+++ b/tests/integration/judge/test_judge.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from autoarena.api import api
@@ -21,7 +23,10 @@ from tests.integration.judge.conftest import api_judge, TEST_JUDGE_MODEL_NAMES
 def test__judge__automated(judge_type: api.JudgeType) -> None:
     model_name = TEST_JUDGE_MODEL_NAMES[judge_type]
     judge_instance = judge_factory(api_judge(judge_type, model_name), wrappers=[retrying_wrapper, cleaning_wrapper])
+    t0 = time.time()
     assert judge_instance.judge("What is 2+2?", "4", "100 million") == "A"
     assert judge_instance.n_requests == 1
     assert judge_instance.total_input_tokens > 0
     assert judge_instance.total_output_tokens > 0
+    assert len(judge_instance.response_seconds) == 1
+    assert judge_instance.response_seconds[0] < time.time() - t0

--- a/tests/integration/service/test_tasks.py
+++ b/tests/integration/service/test_tasks.py
@@ -180,8 +180,8 @@ def test__auto_judge_task__saves_progress(
     log_stream: Callable[[], str],
 ) -> None:
     class CrashesAfter3Judge(AutomatedJudge):
-        def __init__(self, model_name: str, system_prompt: str):
-            super().__init__(model_name, system_prompt)
+        def __init__(self, name: str, model_name: str, system_prompt: str):
+            super().__init__(name, model_name, system_prompt)
             self.seen = 0
 
         def judge(self, prompt: str, response_a: str, response_b: str) -> str:


### PR DESCRIPTION
Print information to the console and task logs:

```
[2024-09-16 09:06:37] 'command-r' used 59768 input tokens and 81 output tokens over 81 requests
[2024-09-16 09:06:37]   * p50 latency: 0.154 seconds
[2024-09-16 09:06:37]   * p90 latency: 0.230 seconds
[2024-09-16 09:06:37]   * p99 latency: 0.336 seconds
```

Also warn in the console when a given request takes longer than `SLOW_THRESHOLD_SECONDS`.