### PR TITLE
Use streaming responses for active tasks

### DIFF
--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -104,6 +104,11 @@ class Task:
 
 
 @dataclass(frozen=True)
+class HasActiveTasks:
+    has_active: bool
+
+
+@dataclass(frozen=True)
 class TriggerAutoJudgeRequest:
     judge_ids: list[int]
     fraction: float  # on [0,1]

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -144,7 +144,7 @@ def router() -> APIRouter:
         project_slug: str,
         timeout: Optional[float] = None,
     ) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
-        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug, timeout=timeout))
+        return SSEStreamingResponse(TaskService.has_active_stream(project_slug, timeout=timeout))
 
     @r.delete("/project/{project_slug}/tasks/completed")
     def delete_completed(project_slug: str) -> None:

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
 from autoarena.api import api
-from autoarena.api.utils import as_sse_stream
+from autoarena.api.utils import SSEStreamingResponse
 from autoarena.error import NotFoundError, BadRequestError
 from autoarena.service.elo import EloService
 from autoarena.service.fine_tuning import FineTuningService
@@ -136,13 +136,11 @@ def router() -> APIRouter:
 
     @r.get("/project/{project_slug}/task/{task_id}/stream")
     async def get_task_stream(project_slug: str, task_id: int) -> StreamingResponse:  # Iterator[api.Task]
-        sse_stream = as_sse_stream(TaskService.get_stream(project_slug, task_id))
-        return StreamingResponse(sse_stream, media_type="text/event-stream")
+        return SSEStreamingResponse(TaskService.get_stream(project_slug, task_id))
 
     @r.get("/project/{project_slug}/tasks/has-active")
     async def get_has_active_tasks_stream(project_slug: str) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
-        sse_stream = as_sse_stream(TaskService.get_has_active_stream(project_slug))
-        return StreamingResponse(sse_stream, media_type="text/event-stream")
+        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug))
 
     @r.delete("/project/{project_slug}/tasks/completed")
     def delete_completed(project_slug: str) -> None:

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from io import BytesIO, StringIO
+from typing import Optional
 
 import pandas as pd
 from fastapi import APIRouter, UploadFile, BackgroundTasks
@@ -139,8 +140,11 @@ def router() -> APIRouter:
         return SSEStreamingResponse(TaskService.get_stream(project_slug, task_id))
 
     @r.get("/project/{project_slug}/tasks/has-active")
-    async def get_has_active_tasks_stream(project_slug: str) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
-        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug))
+    async def get_has_active_tasks_stream(
+        project_slug: str,
+        maximum: Optional[int] = None,
+    ) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
+        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug, stop_after=maximum))
 
     @r.delete("/project/{project_slug}/tasks/completed")
     def delete_completed(project_slug: str) -> None:

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -142,9 +142,9 @@ def router() -> APIRouter:
     @r.get("/project/{project_slug}/tasks/has-active")
     async def get_has_active_tasks_stream(
         project_slug: str,
-        maximum: Optional[int] = None,
+        timeout: Optional[float] = None,
     ) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
-        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug, stop_after=maximum))
+        return SSEStreamingResponse(TaskService.get_has_active_stream(project_slug, timeout=timeout))
 
     @r.delete("/project/{project_slug}/tasks/completed")
     def delete_completed(project_slug: str) -> None:

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -135,8 +135,13 @@ def router() -> APIRouter:
         return TaskService.get_all(project_slug)
 
     @r.get("/project/{project_slug}/task/{task_id}/stream")
-    def get_task_stream(project_slug: str, task_id: int) -> StreamingResponse:  # Iterator[api.Task]
+    async def get_task_stream(project_slug: str, task_id: int) -> StreamingResponse:  # Iterator[api.Task]
         sse_stream = as_sse_stream(TaskService.get_stream(project_slug, task_id))
+        return StreamingResponse(sse_stream, media_type="text/event-stream")
+
+    @r.get("/project/{project_slug}/tasks/has-active")
+    async def get_has_active_tasks_stream(project_slug: str) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
+        sse_stream = as_sse_stream(TaskService.get_has_active_stream(project_slug))
         return StreamingResponse(sse_stream, media_type="text/event-stream")
 
     @r.delete("/project/{project_slug}/tasks/completed")

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -7,6 +7,7 @@ from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
 from autoarena.api import api
+from autoarena.api.utils import as_sse_stream
 from autoarena.error import NotFoundError, BadRequestError
 from autoarena.service.elo import EloService
 from autoarena.service.fine_tuning import FineTuningService
@@ -132,6 +133,11 @@ def router() -> APIRouter:
     @r.get("/project/{project_slug}/tasks")
     def get_tasks(project_slug: str) -> list[api.Task]:
         return TaskService.get_all(project_slug)
+
+    @r.get("/project/{project_slug}/task/{task_id}/stream")
+    def get_task_stream(project_slug: str, task_id: int) -> StreamingResponse:  # Iterator[api.Task]
+        sse_stream = as_sse_stream(TaskService.get_stream(project_slug, task_id))
+        return StreamingResponse(sse_stream, media_type="text/event-stream")
 
     @r.delete("/project/{project_slug}/tasks/completed")
     def delete_completed(project_slug: str) -> None:

--- a/autoarena/api/utils.py
+++ b/autoarena/api/utils.py
@@ -1,11 +1,18 @@
-from typing import Iterator, TypeVar
+from typing import TypeVar, AsyncIterator
 
 from pydantic import RootModel
+from starlette.responses import StreamingResponse
 
 T = TypeVar("T")  # should be a Pydantic dataclass
 
 
-def as_sse_stream(object_stream: Iterator[T]) -> Iterator[str]:
-    for obj in object_stream:
+async def as_sse_stream(object_stream: AsyncIterator[T]) -> AsyncIterator[str]:
+    async for obj in object_stream:
         obj_json = RootModel[T](obj).model_dump_json()
         yield f"data: {obj_json}\n\n"
+
+
+# TODO: figure out a way to gracefully terminate this when the server is exiting
+class SSEStreamingResponse(StreamingResponse):
+    def __init__(self, object_stream: AsyncIterator[T]):
+        super().__init__(as_sse_stream(object_stream), media_type="text/event-stream")

--- a/autoarena/api/utils.py
+++ b/autoarena/api/utils.py
@@ -1,13 +1,11 @@
-import json
 from typing import Iterator, TypeVar
 
 from pydantic import RootModel
 
-T = TypeVar("T")
+T = TypeVar("T")  # should be a Pydantic dataclass
 
 
 def as_sse_stream(object_stream: Iterator[T]) -> Iterator[str]:
     for obj in object_stream:
         obj_json = RootModel[T](obj).model_dump_json()
-        sse_dict = dict(message=f"event: {obj_json}\n")
-        yield f"data: {json.dumps(sse_dict)}\n\n"
+        yield f"data: {obj_json}\n\n"

--- a/autoarena/api/utils.py
+++ b/autoarena/api/utils.py
@@ -1,0 +1,13 @@
+import json
+from typing import Iterator, TypeVar
+
+from pydantic import RootModel
+
+T = TypeVar("T")
+
+
+def as_sse_stream(object_stream: Iterator[T]) -> Iterator[str]:
+    for obj in object_stream:
+        obj_json = RootModel[T](obj).model_dump_json()
+        sse_dict = dict(message=f"event: {obj_json}\n")
+        yield f"data: {json.dumps(sse_dict)}\n\n"

--- a/autoarena/main.py
+++ b/autoarena/main.py
@@ -40,5 +40,11 @@ def main(args: list[str]) -> None:
     if parsed_args.command == "seed":
         seed_head_to_heads(parsed_args.head_to_heads)
     if parsed_args.command == "serve":
-        dev = getattr(parsed_args, "dev", False)
-        uvicorn.run("autoarena.server:server", host="localhost", port=8899, reload=dev, factory=True)
+        uvicorn.run(
+            "autoarena.server:server",
+            host="localhost",
+            port=8899,
+            reload=getattr(parsed_args, "dev", False),
+            factory=True,
+            timeout_graceful_shutdown=1,  # wait 1 second for tasks to complete before forcefully exiting
+        )

--- a/autoarena/service/elo.py
+++ b/autoarena/service/elo.py
@@ -53,11 +53,12 @@ class EloService:
             conn.execute(
                 """
                 UPDATE model
-                SET elo = df_elo.elo, q025 = df_elo.q025, q975 = df_elo.q975
+                SET elo = IFNULL(df_elo.elo, $default_elo), q025 = df_elo.q025, q975 = df_elo.q975
                 FROM model m2
                 LEFT JOIN df_elo ON df_elo.model = m2.name -- left join to set null values for any models without votes
                 WHERE model.id = m2.id;
                 """,
+                dict(default_elo=config.default_score),
             )
 
     # most elo-related code is from https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/monitor/elo_analysis.py

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -50,9 +50,11 @@ class TaskService:
 
     @staticmethod
     async def get_stream(project_slug: str, task_id: int) -> AsyncIterator[api.Task]:
-        done_statuses = {api.TaskStatus.COMPLETED, api.TaskStatus.FAILED}
-        while (task := TaskService.get(project_slug, task_id)).status not in done_statuses:
+        while True:
+            task = TaskService.get(project_slug, task_id)
             yield task
+            if task.status in {api.TaskStatus.COMPLETED, api.TaskStatus.FAILED}:
+                break
             await asyncio.sleep(0.2)
 
     @staticmethod

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -34,7 +34,7 @@ class TaskService:
         while task.status != api.TaskStatus.COMPLETED and task.status != api.TaskStatus.FAILED:
             task = TaskService.get(project_slug, task_id)
             yield task
-            time.sleep(1)  # TODO: better way to do this?
+            time.sleep(0.2)  # TODO: better way to do this?
 
     @staticmethod
     def create(project_slug: str, task_type: api.TaskType, log: str = "Started") -> api.Task:

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -45,9 +45,8 @@ class TaskService:
 
     @staticmethod
     async def get_stream(project_slug: str, task_id: int) -> AsyncIterator[api.Task]:
-        task = TaskService.get(project_slug, task_id)
-        while task.status != api.TaskStatus.COMPLETED and task.status != api.TaskStatus.FAILED:
-            task = TaskService.get(project_slug, task_id)
+        done_statuses = {api.TaskStatus.COMPLETED, api.TaskStatus.FAILED}
+        while (task := TaskService.get(project_slug, task_id)).status not in done_statuses:
             yield task
             await asyncio.sleep(0.2)
 

--- a/tests/integration/api/test_tasks.py
+++ b/tests/integration/api/test_tasks.py
@@ -19,12 +19,11 @@ def test__tasks__get(project_client: TestClient) -> None:
 
 
 def test__tasks__has_active(project_client: TestClient) -> None:
-    requested_event_count = 2
-    response = project_client.get("/tasks/has-active", params=dict(maximum=requested_event_count))
+    response = project_client.get("/tasks/has-active", params=dict(timeout=1.5))
     assert response.status_code == 200
     responses = parse_sse_stream(response.read())
-    assert len(responses) == requested_event_count
-    assert all(r == dict(has_active=False) for r in responses)
+    assert len(responses) == 1  # should only yield one message as the answer does not change in the timeout period
+    assert responses[0] == dict(has_active=False)
 
 
 def test__tasks__stream(project_client: TestClient, model_ids: list[int]) -> None:

--- a/tests/integration/api/test_tasks.py
+++ b/tests/integration/api/test_tasks.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi.testclient import TestClient
 
 
@@ -10,6 +12,15 @@ def test__tasks__get(project_client: TestClient) -> None:
     assert tasks[0]["task_type"] == "fine-tune"
     assert tasks[0]["progress"] < 1
     assert len(tasks[0]["status"]) > 0
+
+
+def test__tasks__has_active(project_client: TestClient) -> None:
+    requested_event_count = 2
+    response = project_client.get("/tasks/has-active", params=dict(maximum=requested_event_count))
+    assert response.status_code == 200
+    responses = [r.split("data: ")[-1] for r in response.read().decode("utf-8").split("\n\n") if r != ""]
+    assert len(responses) == requested_event_count
+    assert all(json.loads(r) == dict(has_active=False) for r in responses)
 
 
 def test__tasks__delete_completed(project_client: TestClient) -> None:

--- a/tests/integration/api/test_tasks.py
+++ b/tests/integration/api/test_tasks.py
@@ -26,7 +26,7 @@ def test__tasks__has_active(project_client: TestClient) -> None:
     assert responses[0] == dict(has_active=False)
 
 
-def test__tasks__stream(project_client: TestClient, model_ids: list[int]) -> None:
+def test__tasks__get_stream(project_client: TestClient, model_ids: list[int]) -> None:
     assert project_client.delete(f"/model/{model_ids[0]}").json() is None  # kicks off a leaderboard recompute
     tasks = project_client.get("/tasks").json()
     assert len(tasks) == 1

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "@mantine/form": "^7.12.0",
     "@mantine/hooks": "^7.11.2",
     "@mantine/notifications": "^7.12.2",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@tabler/icons-react": "^3.11.0",
     "@tanstack/react-query": "^5.51.16",
     "@types/ramda": "^0.30.2",

--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -11,8 +11,11 @@ type Props = {
 };
 export function TaskAccordionItem({ task: inputTask }: Props) {
   const { projectSlug = '' } = useUrlState();
-  const enabled = !taskIsDone(inputTask.status);
-  const { data: task = inputTask } = useTaskStream(projectSlug, inputTask, enabled);
+  const { data: task = inputTask } = useTaskStream({
+    projectSlug,
+    task: inputTask,
+    options: { enabled: !taskIsDone(inputTask.status) },
+  });
 
   const slug = `${task.task_type}-${moment(task.created).format('YYYYMMDD-hhmmss-SSS')}`;
   const IconComponent =

--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -3,11 +3,17 @@ import { IconBooks, IconCalculator, IconGavel } from '@tabler/icons-react';
 import { Accordion, Badge, Code, Group, Progress, Stack, Text } from '@mantine/core';
 import { Task } from '../../hooks/useTasks.ts';
 import { taskIsDone, taskStatusToColor, taskStatusToLabel } from '../../lib/tasks.ts/utils.ts';
+import { useTaskStream } from '../../hooks/useTaskStream.ts';
+import { useUrlState } from '../../hooks/useUrlState.ts';
 
 type Props = {
   task: Task;
 };
-export function TaskAccordionItem({ task }: Props) {
+export function TaskAccordionItem({ task: inputTask }: Props) {
+  const { projectSlug = '' } = useUrlState();
+  const enabled = !taskIsDone(inputTask.status);
+  const task = useTaskStream(projectSlug, inputTask, enabled);
+
   const slug = `${task.task_type}-${moment(task.created).format('YYYYMMDD-hhmmss-SSS')}`;
   const IconComponent =
     task.task_type === 'recompute-leaderboard'
@@ -27,6 +33,7 @@ export function TaskAccordionItem({ task }: Props) {
       : task.task_type === 'auto-judge'
         ? 'var(--mantine-color-orange-6)'
         : 'var(--mantine-color-green-6)';
+
   return (
     <Accordion.Item value={slug}>
       <Accordion.Control icon={<IconComponent size={24} color={iconColor} />}>

--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function TaskAccordionItem({ task: inputTask }: Props) {
   const { projectSlug = '' } = useUrlState();
   const enabled = !taskIsDone(inputTask.status);
-  const task = useTaskStream(projectSlug, inputTask, enabled);
+  const { data: task = inputTask } = useTaskStream(projectSlug, inputTask, enabled);
 
   const slug = `${task.task_type}-${moment(task.created).format('YYYYMMDD-hhmmss-SSS')}`;
   const IconComponent =

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -20,7 +20,7 @@ export function TasksDrawer() {
   const [isDrawerOpen, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure(false);
   const queryClient = useQueryClient();
   const [isCompletedTasksOpen, { toggle: toggleCompletedTasks, close: closeCompletedTasks }] = useDisclosure(false);
-  const { data: hasActiveTasks } = useHasActiveTasksStream(projectSlug);
+  const { data: hasActiveTasks = false } = useHasActiveTasksStream(projectSlug);
   const { data: tasks } = useTasks({ projectSlug });
   const { mutate: clearCompletedTasks } = useClearCompletedTasks({ projectSlug });
 

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -4,7 +4,7 @@ import { useDisclosure } from '@mantine/hooks';
 import moment from 'moment';
 import { useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useTasks } from '../../hooks/useTasks.ts';
+import { getTasksQueryKey, useTasks } from '../../hooks/useTasks.ts';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { pluralize } from '../../lib/string.ts';
 import { getModelsQueryKey } from '../../hooks/useModels.ts';
@@ -12,6 +12,7 @@ import { useClearCompletedTasks } from '../../hooks/useClearCompletedTasks.ts';
 import { taskIsDone } from '../../lib/tasks.ts/utils.ts';
 import { getProjectUrl } from '../../lib/routes.ts';
 import { getJudgesQueryKey } from '../../hooks/useJudges.ts';
+import { useHasActiveTasksStream } from '../../hooks/useHasActiveTasksStream.ts';
 import { TaskAccordionItem } from './TaskAccordionItem.tsx';
 
 export function TasksDrawer() {
@@ -19,17 +20,17 @@ export function TasksDrawer() {
   const [isDrawerOpen, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure(false);
   const queryClient = useQueryClient();
   const [isCompletedTasksOpen, { toggle: toggleCompletedTasks, close: closeCompletedTasks }] = useDisclosure(false);
-  const { data: tasks } = useTasks({
-    projectSlug: projectSlug,
-    // options: { refetchInterval: isDrawerOpen ? 1_000 : 10_000 }, // TODO: polling this every 10 seconds on the app isn't great
-    // options: { refetchInterval: 10_000 },
-  });
-  const { mutate: clearCompletedTasks } = useClearCompletedTasks({ projectSlug: projectSlug });
+  const hasActiveTasks = useHasActiveTasksStream(projectSlug);
+  const { data: tasks } = useTasks({ projectSlug });
+  const { mutate: clearCompletedTasks } = useClearCompletedTasks({ projectSlug });
 
-  // TODO: any task you're watching in the drawer disappears into the collapsed completed section when it finishes
   const tasksSorted = useMemo(() => (tasks ?? []).sort((a, b) => moment(b.created).diff(moment(a.created))), [tasks]);
   const tasksInProgress = useMemo(() => tasksSorted.filter(({ status }) => !taskIsDone(status)), [tasksSorted]);
   const tasksCompleted = useMemo(() => tasksSorted.filter(({ status }) => taskIsDone(status)), [tasksSorted]);
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: getTasksQueryKey(projectSlug ?? '') });
+  }, [isDrawerOpen]);
 
   // reload models and any related queries if any tasks are newly completed
   useEffect(() => {
@@ -44,7 +45,7 @@ export function TasksDrawer() {
         variant="light"
         onClick={toggleDrawer}
         leftSection={
-          tasksInProgress.length > 0 ? (
+          hasActiveTasks ? (
             <Loader size={18} type="bars" />
           ) : (
             <IconCpu width={20} height={20} color="var(--mantine-color-kolena-8)" />
@@ -65,8 +66,8 @@ export function TasksDrawer() {
         title={
           <Text fs="italic" c="dimmed" size="sm">
             {tasksInProgress.length > 0
-              ? `Showing ${pluralize(tasksInProgress.length, 'in-progress task')}`
-              : 'No in-progress tasks'}
+              ? `Showing ${pluralize(tasksInProgress.length, 'active task')}`
+              : 'No active tasks'}
           </Text>
         }
       >

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -21,7 +21,8 @@ export function TasksDrawer() {
   const [isCompletedTasksOpen, { toggle: toggleCompletedTasks, close: closeCompletedTasks }] = useDisclosure(false);
   const { data: tasks } = useTasks({
     projectSlug: projectSlug,
-    options: { refetchInterval: isDrawerOpen ? 1_000 : 10_000 }, // TODO: polling this every 10 seconds on the app isn't great
+    // options: { refetchInterval: isDrawerOpen ? 1_000 : 10_000 }, // TODO: polling this every 10 seconds on the app isn't great
+    // options: { refetchInterval: 10_000 },
   });
   const { mutate: clearCompletedTasks } = useClearCompletedTasks({ projectSlug: projectSlug });
 

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -20,7 +20,7 @@ export function TasksDrawer() {
   const [isDrawerOpen, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure(false);
   const queryClient = useQueryClient();
   const [isCompletedTasksOpen, { toggle: toggleCompletedTasks, close: closeCompletedTasks }] = useDisclosure(false);
-  const hasActiveTasks = useHasActiveTasksStream(projectSlug);
+  const { data: hasActiveTasks } = useHasActiveTasksStream(projectSlug);
   const { data: tasks } = useTasks({ projectSlug });
   const { mutate: clearCompletedTasks } = useClearCompletedTasks({ projectSlug });
 

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { getProjectUrl } from '../lib/routes.ts';
+
+export function useHasActiveTasksStream(projectSlug?: string) {
+  const [hasActiveTasks, setHasActiveTasks] = useState(false);
+  const controller = new AbortController();
+
+  useEffect(() => {
+    if (projectSlug == null) {
+      return;
+    }
+    const fetchData = async () => {
+      // TODO: add proper abort controller
+      await fetchEventSource(`${getProjectUrl(projectSlug)}/tasks/has-active`, {
+        method: 'GET',
+        headers: { Accept: 'text/event-stream' },
+        signal: controller.signal,
+        onmessage: event => {
+          const parsedData: { has_active: boolean } = JSON.parse(event.data);
+          setHasActiveTasks(parsedData.has_active);
+        },
+      });
+    };
+    fetchData();
+  }, [projectSlug]);
+
+  return hasActiveTasks;
+}

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -11,7 +11,6 @@ export function useHasActiveTasksStream(projectSlug?: string) {
       return;
     }
     const fetchData = async () => {
-      // TODO: add proper abort controller
       await fetchEventSource(`${getProjectUrl(projectSlug)}/tasks/has-active`, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
@@ -25,5 +24,5 @@ export function useHasActiveTasksStream(projectSlug?: string) {
     fetchData();
   }, [projectSlug]);
 
-  return hasActiveTasks;
+  return { data: hasActiveTasks, controller };
 }

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -1,5 +1,5 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
-import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, useQueryClient, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { getProjectUrl } from '../lib/routes.ts';
 import { Task } from './useTasks.ts';
 
@@ -7,7 +7,12 @@ function getTaskStreamQueryKey(projectSlug: string, task: Task) {
   return [getProjectUrl(projectSlug), '/task', task.id, '/stream'];
 }
 
-export function useTaskStream(projectSlug: string, task: Task, enabled: boolean): UseQueryResult<Task, Error> {
+type Params = {
+  projectSlug: string;
+  task: Task;
+  options?: Partial<UseQueryOptions<Task, Error>>;
+};
+export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQueryResult<Task, Error> {
   const queryClient = useQueryClient();
   const queryKey = getTaskStreamQueryKey(projectSlug, task);
 
@@ -28,6 +33,6 @@ export function useTaskStream(projectSlug: string, task: Task, enabled: boolean)
       return latest;
     },
     initialData: task,
-    enabled,
+    ...options,
   });
 }

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { getProjectUrl } from '../lib/routes.ts';
+import { Task } from './useTasks.ts';
+
+export function useTaskStream(projectSlug: string, task: Task, enabled: boolean) {
+  const [taskFromStream, setTaskFromStream] = useState<Task>(task);
+  const controller = new AbortController();
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const fetchData = async () => {
+      // TODO: add proper abort controller
+      await fetchEventSource(`${getProjectUrl(projectSlug)}/task/${task.id}/stream`, {
+        method: 'GET',
+        headers: { Accept: 'text/event-stream' },
+        signal: controller.signal,
+        onmessage: event => {
+          const parsedData: Task = JSON.parse(event.data);
+          setTaskFromStream(parsedData);
+        },
+      });
+    };
+    fetchData();
+  }, [task.id, enabled]);
+
+  return taskFromStream;
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -829,6 +829,11 @@
   resolved "https://registry.yarnpkg.com/@mantine/store/-/store-7.12.2.tgz#da576a63d860d44525bd18c9dd3977b6d2840011"
   integrity sha512-NqL31sO/KcAETEWP/CiXrQOQNoE4168vZsxyXacQHGBueVMJa64WIDQtKLHrCnFRMws3vsXF02/OO4bH4XGcMQ==
 
+"@microsoft/fetch-event-source@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"
+  integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
Rather than polling the `/tasks` endpoint, use streaming responses for:

- `/task/{task_id}/stream`: getting the latest information about an active task
- `/tasks/has-active`: controlling the state of the loading spinner on the tasks drawer button

This improves the tasks UX by making updates snappier and sending off fewer requests that clutter the service logs. It also fixes a UX bug where tasks would disappear into the "completed tasks" bin immediately after completing, which is annoying as you're often actively watching tasks that are nearing completion.