### PR TITLE
Deterministic initial sort order in expanded model details table

### DIFF
--- a/ui/src/hooks/usePagination.ts
+++ b/ui/src/hooks/usePagination.ts
@@ -8,7 +8,7 @@ type Params<T> = {
 export function usePagination<T>({ records, withHotkeys = false }: Params<T>) {
   const [pageNumber, setPageNumber] = useState(1);
   const [pageSize, setPageSizeState] = useState(10);
-  const [pageRecords, setPageRecordsState] = useState(records.slice(0, pageSize));
+  const [pageRecords, setPageRecordsState] = useState<T[]>(records.slice(0, pageSize));
 
   function setPageRecords() {
     const startIndex = (pageNumber - 1) * pageSize;


### PR DESCRIPTION
Add a `sort_slug` that yields a deterministic initial sort order for the expanded model details H2H table. This means that rows won't shift around when the data is refetched on reopen.