### PR TITLE
Gracefully handle unrecognized judge types

### DIFF
--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -125,6 +125,7 @@ class JudgeType(str, Enum):
     TOGETHER = "together"
     BEDROCK = "bedrock"
     CUSTOM = "custom"  # TODO: not sure how to handle calling this yet -- will it just be another Ollama model?
+    UNKNOWN = "unknown"  # catchall to gracefully handle newer judge types that are not present on an older release
 
 
 @dataclass(frozen=True)

--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -125,7 +125,7 @@ class JudgeType(str, Enum):
     TOGETHER = "together"
     BEDROCK = "bedrock"
     CUSTOM = "custom"  # TODO: not sure how to handle calling this yet -- will it just be another Ollama model?
-    UNKNOWN = "unknown"  # catchall to gracefully handle newer judge types that are not present on an older release
+    UNRECOGNIZED = "unrecognized"  # catchall to gracefully handle newer types that are not present on an older release
 
 
 @dataclass(frozen=True)

--- a/autoarena/judge/factory.py
+++ b/autoarena/judge/factory.py
@@ -26,8 +26,8 @@ AUTOMATED_JUDGE_TYPE_TO_CLASS: dict[api.JudgeType, type[AutomatedJudge]] = {
 def judge_factory(judge: api.Judge, wrappers: Optional[Sequence[JudgeWrapper]] = None) -> AutomatedJudge:
     if judge.judge_type is api.JudgeType.HUMAN:
         raise ValueError("Automated judge factory cannot instantiate human judge")
-    if judge.judge_type is api.JudgeType.UNKNOWN:
-        raise ValueError("Cannot instantiate unknown judge type -- are you running an older version of AutoArena?")
+    if judge.judge_type is api.JudgeType.UNRECOGNIZED:
+        raise ValueError("Cannot instantiate unrecognized judge type. Are you running an older version of AutoArena?")
     judge_class = (
         get_custom_judge_class(judge.name)
         if judge.judge_type is api.JudgeType.CUSTOM

--- a/autoarena/judge/factory.py
+++ b/autoarena/judge/factory.py
@@ -25,14 +25,16 @@ AUTOMATED_JUDGE_TYPE_TO_CLASS: dict[api.JudgeType, type[AutomatedJudge]] = {
 
 def judge_factory(judge: api.Judge, wrappers: Optional[Sequence[JudgeWrapper]] = None) -> AutomatedJudge:
     if judge.judge_type is api.JudgeType.HUMAN:
-        raise ValueError("automated judge factory cannot instantiate human judge")
+        raise ValueError("Automated judge factory cannot instantiate human judge")
+    if judge.judge_type is api.JudgeType.UNKNOWN:
+        raise ValueError("Cannot instantiate unknown judge type -- are you running an older version of AutoArena?")
     judge_class = (
         get_custom_judge_class(judge.name)
         if judge.judge_type is api.JudgeType.CUSTOM
         else AUTOMATED_JUDGE_TYPE_TO_CLASS[judge.judge_type]
     )
     if not issubclass(judge_class, AutomatedJudge) or judge.model_name is None or judge.system_prompt is None:
-        raise ValueError(f"misconfigured judge: {judge}")
+        raise ValueError(f"Misconfigured judge: {judge}")
     for wrapper in wrappers or []:
         judge_class = wrapper(judge_class)
     return judge_class(judge.name, judge.model_name, judge.system_prompt)

--- a/autoarena/judge/factory.py
+++ b/autoarena/judge/factory.py
@@ -41,6 +41,8 @@ def judge_factory(judge: api.Judge, wrappers: Optional[Sequence[JudgeWrapper]] =
 
 
 def verify_judge_type_environment(judge_type: api.JudgeType) -> None:
+    if judge_type is api.JudgeType.UNRECOGNIZED:
+        raise ValueError("Unable to run unrecognized judge type")
     judge_class = AUTOMATED_JUDGE_TYPE_TO_CLASS.get(judge_type, None)
     if judge_class is not None:
         judge_class.verify_environment()

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -40,6 +40,8 @@ class JudgeService:
                 ORDER BY j.id
                 """,
             ).df()
+        judge_types = {j for j in api.JudgeType}
+        df_task["judge_type"] = df_task["judge_type"].apply(lambda j: j if j in judge_types else "unknown")
         return [api.Judge(**r) for _, r in df_task.iterrows()]
 
     @staticmethod

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -14,7 +14,7 @@ class JudgeService:
     @staticmethod
     def get_all(project_slug: str) -> list[api.Judge]:
         with ProjectService.connect(project_slug) as conn:
-            df_task = conn.execute(
+            df = conn.execute(
                 """
                 SELECT
                     j.id,
@@ -41,8 +41,8 @@ class JudgeService:
                 """,
             ).df()
         judge_types = {j for j in api.JudgeType}
-        df_task["judge_type"] = df_task["judge_type"].apply(lambda j: j if j in judge_types else "unknown")
-        return [api.Judge(**r) for _, r in df_task.iterrows()]
+        df["judge_type"] = df["judge_type"].apply(lambda j: j if j in judge_types else api.JudgeType.UNRECOGNIZED.value)
+        return [api.Judge(**r) for _, r in df.iterrows()]
 
     @staticmethod
     def create(project_slug: str, request: api.CreateJudgeRequest) -> api.Judge:

--- a/tests/integration/api/test_judges.py
+++ b/tests/integration/api/test_judges.py
@@ -42,9 +42,13 @@ def test__judges__update(project_client: TestClient, judge_id: int) -> None:
     assert not updated_judge["enabled"]
 
 
-def test__judges__can_access(project_client: TestClient) -> None:
+def test__judges__can_access__human(project_client: TestClient) -> None:
     # just ensure that the API works; full behavior is tested at a lower level than the API
     assert project_client.get("/judge/human/can-access").json()
+
+
+def test__judges__can_access__unrecognized__failed(project_client: TestClient) -> None:
+    assert not project_client.get("/judge/unrecognized/can-access").json()
 
 
 def test__judges__delete(project_client: TestClient, judge_id: int) -> None:

--- a/tests/unit/judge/test_factory.py
+++ b/tests/unit/judge/test_factory.py
@@ -43,3 +43,19 @@ def test__judge_factory__custom(custom_judge_context: None) -> None:
 def test__judge_factory__custom__failed(custom_judge_context: None) -> None:
     with pytest.raises(ValueError):
         judge_factory(CUSTOM_REQUEST)
+
+
+def test__judge_factory__unknown__failed() -> None:
+    judge = api.Judge(
+        id=0,
+        judge_type=api.JudgeType.UNKNOWN,
+        created=datetime.utcnow(),
+        name="something unknown",
+        model_name="anything",
+        system_prompt="anything",
+        description="maybe from a newer version of AutoArena",
+        enabled=True,
+        n_votes=0,
+    )
+    with pytest.raises(ValueError):
+        judge_factory(judge)

--- a/tests/unit/judge/test_factory.py
+++ b/tests/unit/judge/test_factory.py
@@ -45,15 +45,15 @@ def test__judge_factory__custom__failed(custom_judge_context: None) -> None:
         judge_factory(CUSTOM_REQUEST)
 
 
-def test__judge_factory__unknown__failed() -> None:
+def test__judge_factory__unrecognized__failed() -> None:
     judge = api.Judge(
         id=0,
-        judge_type=api.JudgeType.UNKNOWN,
+        judge_type=api.JudgeType.UNRECOGNIZED,
         created=datetime.utcnow(),
-        name="something unknown",
-        model_name="anything",
-        system_prompt="anything",
-        description="maybe from a newer version of AutoArena",
+        name="any-name",
+        model_name="any-model-name",
+        system_prompt="Say hi!",
+        description="Maybe from a newer version of AutoArena",
         enabled=True,
         n_votes=0,
     )

--- a/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
+++ b/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
@@ -40,15 +40,19 @@ export function CanAccessJudgeStatusIndicator({ judgeType }: Props) {
         </Text>
       ) : (
         <Stack gap={4}>
-          <Text size="sm">Unable to access {judgeTypeName} API.</Text>
+          <Text size="sm">Unable to access {judgeTypeName} API</Text>
           {apiKeyName != null ? (
             <Text size="xs" c="dimmed">
               Ensure that you have the <Code>{apiKeyName}</Code> variable set in the environment running AutoArena.
             </Text>
+          ) : judgeType === 'unrecognized' ? (
+            <Text size="xs" c="dimmed">
+              This judge has an unrecognized type. Ensure that you are running the latest version of AutoArena.
+            </Text>
           ) : (
             <Text size="xs" c="dimmed">
-              Ensure that you have the relevant configuration for the {judgeTypeName}
-              API in the environment running AutoArena.
+              Ensure that you have the relevant configuration for the {judgeTypeName} API in the environment running
+              AutoArena.
             </Text>
           )}
         </Stack>

--- a/ui/src/components/Judges/types.ts
+++ b/ui/src/components/Judges/types.ts
@@ -27,7 +27,8 @@ export type JudgeType =
   | 'cohere'
   | 'together'
   | 'bedrock'
-  | 'custom';
+  | 'custom'
+  | 'unrecognized';
 
 export function judgeTypeIconComponent(judgeType: JudgeType) {
   // TODO: get SVGs for real Ollama, Anthropic, Cohere, and Together logos
@@ -49,6 +50,7 @@ export function judgeTypeIconComponent(judgeType: JudgeType) {
     case 'bedrock':
       return IconBrandAws;
     case 'custom':
+    case 'unrecognized':
     default:
       return IconRobot;
   }
@@ -73,6 +75,7 @@ export function judgeTypeToCoverImageUrl(judgeType: JudgeType) {
     case 'custom':
       return customUrl;
     case 'human':
+    case 'unrecognized':
     default:
       return;
   }
@@ -98,6 +101,8 @@ export function judgeTypeToHumanReadableName(judgeType: JudgeType) {
       return 'AWS Bedrock';
     case 'custom':
       return 'Custom Fine-Tune';
+    case 'unrecognized':
+      return 'Unrecognized';
     default:
       return judgeType;
   }


### PR DESCRIPTION
Rather than failing to load the judges if an unrecognized judge is present, mark it as unrecognized and prompt the user to update to the latest version. This may happen if you're running an older version of AutoArena on a newer project that has a saved judge type that has been recently introduced.