### PR TITLE
Add `useAppMode` hook to UI to support local/cloud deployments

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:cloud": "vite --mode cloud",
     "build": "tsc --build && vite build",
+    "build:cloud": "tsc --build && vite build --mode cloud",
     "lint": "eslint '*/**/*.{ts,tsx}' --max-warnings=0 && stylelint '*/**/*.{css,scss}'",
     "lint:fix": "eslint '*/**/*.{ts,tsx}' --fix; stylelint '*/**/*.{css,scss}' --fix",
     "lint:staged": "lint-staged",

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -12,8 +12,7 @@ import { JudgeAccordionItem } from './JudgeAccordionItem.tsx';
 export function Judges() {
   const { projectSlug } = useUrlState();
   const { data: judges } = useJudges(projectSlug);
-  const appMode = useAppMode();
-  const isLocalMode = appMode == 'local';
+  const { isLocalMode } = useAppMode();
 
   const [isFineTunedOpen, { toggle: toggleFineTuned, close: closeFineTuned }] = useDisclosure(false);
   const [isOllamaOpen, { toggle: toggleOllama, close: closeOllama }] = useDisclosure(false);

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { useJudges } from '../../hooks/useJudges.ts';
 import { ExternalUrls } from '../../lib/routes.ts';
+import { useAppMode } from '../../hooks/useAppMode.ts';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
 import { CreateJudgeModal } from './CreateJudgeModal.tsx';
 import { CreateFineTunedJudgeModal } from './CreateFineTunedJudgeModal.tsx';
@@ -11,6 +12,8 @@ import { JudgeAccordionItem } from './JudgeAccordionItem.tsx';
 export function Judges() {
   const { projectSlug } = useUrlState();
   const { data: judges } = useJudges(projectSlug);
+  const appMode = useAppMode();
+  const isLocalMode = appMode == 'local';
 
   const [isFineTunedOpen, { toggle: toggleFineTuned, close: closeFineTuned }] = useDisclosure(false);
   const [isOllamaOpen, { toggle: toggleOllama, close: closeOllama }] = useDisclosure(false);
@@ -50,31 +53,37 @@ export function Judges() {
             description="Configure an Anthropic model like Claude 3.5 Sonnet or Claude 3 Opus as a judge"
             onClick={toggleAnthropic}
           />
-          <ConfigureJudgeCard
-            judgeType="ollama"
-            description="Configure any local Ollama model as a judge"
-            onClick={toggleOllama}
-          />
+          {isLocalMode && (
+            <ConfigureJudgeCard
+              judgeType="ollama"
+              description="Configure any local Ollama model as a judge"
+              onClick={toggleOllama}
+            />
+          )}
           <ConfigureJudgeCard
             judgeType="cohere"
             description="Configure Command R or Command R+ from Cohere as a judge"
             onClick={toggleCohere}
           />
-          <ConfigureJudgeCard
-            judgeType="gemini"
-            description="Configure a Google Gemini model as a judge"
-            onClick={toggleGemini}
-          />
+          {isLocalMode && (
+            <ConfigureJudgeCard
+              judgeType="gemini"
+              description="Configure a Google Gemini model as a judge"
+              onClick={toggleGemini}
+            />
+          )}
           <ConfigureJudgeCard
             judgeType="together"
             description="Configure a model running on Together AI as a judge"
             onClick={toggleTogether}
           />
-          <ConfigureJudgeCard
-            judgeType="bedrock"
-            description="Configure a model running on AWS Bedrock as a judge"
-            onClick={toggleBedrock}
-          />
+          {isLocalMode && (
+            <ConfigureJudgeCard
+              judgeType="bedrock"
+              description="Configure a model running on AWS Bedrock as a judge"
+              onClick={toggleBedrock}
+            />
+          )}
         </SimpleGrid>
 
         <CreateFineTunedJudgeModal isOpen={isFineTunedOpen} onClose={closeFineTuned} />
@@ -106,50 +115,54 @@ export function Judges() {
             'claude-3-haiku-20240307',
           ]}
         />
-        <CreateJudgeModal
-          isOpen={isOllamaOpen}
-          onClose={closeOllama}
-          judgeType="ollama"
-          extraCopy={
-            <Stack gap={0}>
-              <Text size="sm">
-                Enter a model name to use as a judge that runs locally via Ollama. You can specify any model that can be
-                downloaded from{' '}
-                <Anchor href={ExternalUrls.OLLAMA_MODELS} target="_blank">
-                  Ollama
-                </Anchor>
-                . Some examples include:
-              </Text>
-              <ul>
-                <li>
-                  <Code>llama3.1:8b</Code>
-                </li>
-                <li>
-                  <Code>gemma2:9b</Code>
-                </li>
-                <li>
-                  <Code>mistral-nemo:12b</Code>
-                </li>
-              </ul>
-              <Text size="sm">
-                Note that this model must be pulled via <Code>ollama pull</Code> and the Ollama service must be running
-                on the host running AutoArena.
-              </Text>
-            </Stack>
-          }
-        />
+        {isLocalMode && (
+          <CreateJudgeModal
+            isOpen={isOllamaOpen}
+            onClose={closeOllama}
+            judgeType="ollama"
+            extraCopy={
+              <Stack gap={0}>
+                <Text size="sm">
+                  Enter a model name to use as a judge that runs locally via Ollama. You can specify any model that can
+                  be downloaded from{' '}
+                  <Anchor href={ExternalUrls.OLLAMA_MODELS} target="_blank">
+                    Ollama
+                  </Anchor>
+                  . Some examples include:
+                </Text>
+                <ul>
+                  <li>
+                    <Code>llama3.1:8b</Code>
+                  </li>
+                  <li>
+                    <Code>gemma2:9b</Code>
+                  </li>
+                  <li>
+                    <Code>mistral-nemo:12b</Code>
+                  </li>
+                </ul>
+                <Text size="sm">
+                  Note that this model must be pulled via <Code>ollama pull</Code> and the Ollama service must be
+                  running on the host running AutoArena.
+                </Text>
+              </Stack>
+            }
+          />
+        )}
         <CreateJudgeModal
           isOpen={isCohereOpen}
           onClose={closeCohere}
           judgeType="cohere"
           modelOptions={['command-r-plus', 'command-r']}
         />
-        <CreateJudgeModal
-          isOpen={isGeminiOpen}
-          onClose={closeGemini}
-          judgeType="gemini"
-          modelOptions={['gemini-1.5-flash', 'gemini-1.5-pro']}
-        />
+        {isLocalMode && (
+          <CreateJudgeModal
+            isOpen={isGeminiOpen}
+            onClose={closeGemini}
+            judgeType="gemini"
+            modelOptions={['gemini-1.5-flash', 'gemini-1.5-pro']}
+          />
+        )}
         <CreateJudgeModal
           isOpen={isTogetherOpen}
           onClose={closeTogether}
@@ -164,51 +177,53 @@ export function Judges() {
             </Text>
           }
         />
-        <CreateJudgeModal
-          isOpen={isBedrockOpen}
-          onClose={closeBedrock}
-          judgeType="bedrock"
-          modelOptions={[
-            'anthropic.claude-3-5-sonnet-20240620-v1:0',
-            'anthropic.claude-3-opus-20240229-v1:0',
-            'anthropic.claude-3-sonnet-20240229-v1:0',
-            'anthropic.claude-3-haiku-20240307-v1:0',
-            'cohere.command-r-v1:0',
-            'cohere.command-r-plus-v1:0',
-            'meta.llama3-8b-instruct-v1:0',
-            'meta.llama3-70b-instruct-v1:0',
-            'meta.llama3-1-8b-instruct-v1:0',
-            'meta.llama3-1-70b-instruct-v1:0',
-            'meta.llama3-1-405b-instruct-v1:0',
-            'mistral.mistral-large-2402-v1:0',
-            'mistral.mistral-large-2407-v1:0',
-            'mistral.mistral-small-2402-v1:0',
-          ]}
-          extraCopy={
-            <>
-              <Text inherit>
-                Models are called using the{' '}
-                <Code>
-                  <Anchor inherit href={ExternalUrls.BEDROCK_MODELS} target="_blank">
-                    Converse
-                  </Anchor>
-                </Code>{' '}
-                API.
-              </Text>
-              <Text inherit>
-                Using Bedrock models requires a valid AWS{' '}
-                <Text span inherit fw="bold">
-                  authorization
-                </Text>{' '}
-                and{' '}
-                <Text span inherit fw="bold">
-                  region
-                </Text>{' '}
-                configuration in the environment running AutoArena.
-              </Text>
-            </>
-          }
-        />
+        {isLocalMode && (
+          <CreateJudgeModal
+            isOpen={isBedrockOpen}
+            onClose={closeBedrock}
+            judgeType="bedrock"
+            modelOptions={[
+              'anthropic.claude-3-5-sonnet-20240620-v1:0',
+              'anthropic.claude-3-opus-20240229-v1:0',
+              'anthropic.claude-3-sonnet-20240229-v1:0',
+              'anthropic.claude-3-haiku-20240307-v1:0',
+              'cohere.command-r-v1:0',
+              'cohere.command-r-plus-v1:0',
+              'meta.llama3-8b-instruct-v1:0',
+              'meta.llama3-70b-instruct-v1:0',
+              'meta.llama3-1-8b-instruct-v1:0',
+              'meta.llama3-1-70b-instruct-v1:0',
+              'meta.llama3-1-405b-instruct-v1:0',
+              'mistral.mistral-large-2402-v1:0',
+              'mistral.mistral-large-2407-v1:0',
+              'mistral.mistral-small-2402-v1:0',
+            ]}
+            extraCopy={
+              <>
+                <Text inherit>
+                  Models are called using the{' '}
+                  <Code>
+                    <Anchor inherit href={ExternalUrls.BEDROCK_MODELS} target="_blank">
+                      Converse
+                    </Anchor>
+                  </Code>{' '}
+                  API.
+                </Text>
+                <Text inherit>
+                  Using Bedrock models requires a valid AWS{' '}
+                  <Text span inherit fw="bold">
+                    authorization
+                  </Text>{' '}
+                  and{' '}
+                  <Text span inherit fw="bold">
+                    region
+                  </Text>{' '}
+                  configuration in the environment running AutoArena.
+                </Text>
+              </>
+            }
+          />
+        )}
       </Stack>
     </Center>
   );

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -13,7 +13,7 @@ import { useAppMode } from '../hooks/useAppMode.ts';
 
 export function MainMenu() {
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
-  const appMode = useAppMode();
+  const { isCloudMode } = useAppMode();
   return (
     <Menu>
       <Menu.Target>
@@ -41,7 +41,7 @@ export function MainMenu() {
         <Anchor href={ExternalUrls.AUTOARENA_SLACK_COMMUNITY} underline="never" target="_blank">
           <Menu.Item leftSection={<IconBrandSlack {...iconProps} />}>Slack Community</Menu.Item>
         </Anchor>
-        {appMode === 'cloud' && (
+        {isCloudMode && (
           <>
             <Menu.Divider />
             <Anchor underline="never">

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -44,7 +44,7 @@ export function MainMenu() {
         {isCloudMode && (
           <>
             <Menu.Divider />
-            <Anchor href={ExternalUrls.AUTOARENA_CLOUD_LOGOUT} underline="never">
+            <Anchor href="/" /* TODO: logout URL */ underline="never">
               <Menu.Item leftSection={<IconLogout {...iconProps} />}>Log out</Menu.Item>
             </Anchor>
           </>

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -44,7 +44,7 @@ export function MainMenu() {
         {isCloudMode && (
           <>
             <Menu.Divider />
-            <Anchor underline="never">
+            <Anchor href={ExternalUrls.AUTOARENA_CLOUD_LOGOUT} underline="never">
               <Menu.Item leftSection={<IconLogout {...iconProps} />}>Log out</Menu.Item>
             </Anchor>
           </>

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -1,9 +1,19 @@
 import { Anchor, Group, Menu, Text, Tooltip } from '@mantine/core';
-import { IconBeta, IconBrandGithub, IconBrandSlack, IconBug, IconHome, IconStack2Filled } from '@tabler/icons-react';
+import {
+  IconBeta,
+  IconBrandGithub,
+  IconBrandSlack,
+  IconBug,
+  IconHome,
+  IconLogout,
+  IconStack2Filled,
+} from '@tabler/icons-react';
 import { ExternalUrls } from '../lib/routes.ts';
+import { useAppMode } from '../hooks/useAppMode.ts';
 
 export function MainMenu() {
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
+  const appMode = useAppMode();
   return (
     <Menu>
       <Menu.Target>
@@ -31,6 +41,14 @@ export function MainMenu() {
         <Anchor href={ExternalUrls.AUTOARENA_SLACK_COMMUNITY} underline="never" target="_blank">
           <Menu.Item leftSection={<IconBrandSlack {...iconProps} />}>Slack Community</Menu.Item>
         </Anchor>
+        {appMode === 'cloud' && (
+          <>
+            <Menu.Divider />
+            <Anchor underline="never">
+              <Menu.Item leftSection={<IconLogout {...iconProps} />}>Log out</Menu.Item>
+            </Anchor>
+          </>
+        )}
       </Menu.Dropdown>
     </Menu>
   );

--- a/ui/src/hooks/useAppMode.ts
+++ b/ui/src/hooks/useAppMode.ts
@@ -1,5 +1,14 @@
-export type AppMode = 'local' | 'cloud';
+import { useMemo } from 'react';
 
-export function useAppMode(): AppMode {
-  return import.meta.env.MODE === 'cloud' ? 'cloud' : 'local';
+type AppMode = 'local' | 'cloud';
+
+export function useAppMode() {
+  return useMemo(() => {
+    const appMode: AppMode = import.meta.env.MODE === 'cloud' ? 'cloud' : 'local';
+    return {
+      appMode,
+      isLocalMode: appMode === 'local',
+      isCloudMode: appMode === 'cloud',
+    };
+  }, [import.meta.env.MODE]);
 }

--- a/ui/src/hooks/useAppMode.ts
+++ b/ui/src/hooks/useAppMode.ts
@@ -1,0 +1,5 @@
+export type AppMode = 'local' | 'cloud';
+
+export function useAppMode(): AppMode {
+  return import.meta.env.MODE === 'cloud' ? 'cloud' : 'local';
+}

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -9,6 +9,7 @@ export enum ExternalUrls {
   AUTOARENA_GITHUB = 'https://github.com/kolenaIO/autoarena',
   AUTOARENA_GITHUB_ISSUES = 'https://github.com/kolenaIO/autoarena/issues/new',
   AUTOARENA_SLACK_COMMUNITY = 'https://kolena-autoarena.slack.com',
+  AUTOARENA_CLOUD_LOGOUT = '/', // TODO
 
   TOGETHER_MODELS = 'https://docs.together.ai/docs/chat-models',
   OLLAMA_MODELS = 'https://ollama.com/library',

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -9,7 +9,6 @@ export enum ExternalUrls {
   AUTOARENA_GITHUB = 'https://github.com/kolenaIO/autoarena',
   AUTOARENA_GITHUB_ISSUES = 'https://github.com/kolenaIO/autoarena/issues/new',
   AUTOARENA_SLACK_COMMUNITY = 'https://kolena-autoarena.slack.com',
-  AUTOARENA_CLOUD_LOGOUT = '/', // TODO
 
   TOGETHER_MODELS = 'https://docs.together.ai/docs/chat-models',
   OLLAMA_MODELS = 'https://ollama.com/library',


### PR DESCRIPTION
This allows for conditional rendering of various components that are only relevant in either local or cloud environments, such as logging out and using Ollama.

`yarn dev` and `yarn build` are unchanged, with the new `yarn dev:cloud` and `yarn build:cloud` commands for dev and build in cloud mode.