### PR TITLE
Collect app and API routes into single location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,15 +23,3 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-  - repo: local
-    hooks:
-      - id: yarn-lint-fix
-        name: yarn lint:staged
-        entry: /usr/bin/env bash -c 'pushd ui >/dev/null; yarn lint:staged; popd >/dev/null'
-        language: script
-  - repo: local
-    hooks:
-      - id: yarn-typecheck
-        name: yarn typecheck
-        entry: /usr/bin/env bash -c 'pushd ui >/dev/null; yarn typecheck; popd >/dev/null'
-        language: script

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -147,7 +147,7 @@ def router() -> APIRouter:
         return SSEStreamingResponse(TaskService.has_active_stream(project_slug, timeout=timeout))
 
     @r.delete("/project/{project_slug}/tasks/completed")
-    def delete_completed(project_slug: str) -> None:
+    def delete_completed_tasks(project_slug: str) -> None:
         TaskService.delete_completed(project_slug)
 
     @r.post("/project/{project_slug}/task/auto-judge")
@@ -189,7 +189,7 @@ def router() -> APIRouter:
             pass
 
     @r.put("/project/{project_slug}/elo/reseed-scores")
-    def reseed_scores(project_slug: str) -> None:
+    def reseed_elo_scores(project_slug: str) -> None:
         EloService.reseed_scores(project_slug)
 
     @r.post("/project/{project_slug}/fine-tune")

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,7 @@
     ]
   },
   "dependencies": {
+    "@auth0/auth0-react": "^2.2.4",
     "@mantine/charts": "^7.12.2",
     "@mantine/core": "^7.11.2",
     "@mantine/form": "^7.12.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,9 +7,11 @@ import { createTheme, MantineProvider, Modal, Popover, Tooltip } from '@mantine/
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Notifications } from '@mantine/notifications';
+import { Auth0Provider } from '@auth0/auth0-react';
 import { Page, TAB_COMPARISON, TAB_JUDGES, TAB_LEADERBOARD } from './components/Page.tsx';
 import { PageNotFound } from './components/PageNotFound.tsx';
-import { getAppMode } from './hooks/useAppMode.ts';
+import { getAppMode, useAppMode } from './hooks/useAppMode.ts';
+import { AUTH0 } from './lib/auth.ts';
 
 const theme = createTheme({
   primaryColor: 'kolena',
@@ -50,13 +52,27 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  return (
+  const { isLocalMode } = useAppMode();
+  const AppComponent = (
     <QueryClientProvider client={queryClient}>
       <MantineProvider forceColorScheme="light" defaultColorScheme="light" theme={theme}>
         <Notifications />
         <RouterProvider router={router} />
       </MantineProvider>
     </QueryClientProvider>
+  );
+  return isLocalMode ? (
+    AppComponent
+  ) : (
+    <Auth0Provider
+      domain={AUTH0.DOMAIN}
+      clientId={AUTH0.CLIENT_ID}
+      authorizationParams={{ redirect_uri: `${window.location.origin}/redirect`, audience: AUTH0.API_AUDIENCE }}
+      useRefreshTokens
+      cacheLocation="localstorage"
+    >
+      {AppComponent}
+    </Auth0Provider>
   );
 }
 

--- a/ui/src/components/DeleteModelButton.tsx
+++ b/ui/src/components/DeleteModelButton.tsx
@@ -12,10 +12,10 @@ type Props = {
 export function DeleteModelButton({ model }: Props) {
   const { projectSlug = '' } = useUrlState();
   const [isOpen, { toggle, close }] = useDisclosure(false);
-  const { mutate: deleteModel } = useDeleteModel({ projectSlug });
+  const { mutate: deleteModel } = useDeleteModel({ projectSlug, modelId: model.id });
 
   function handleDelete() {
-    deleteModel(model.id);
+    deleteModel();
     close();
   }
 

--- a/ui/src/components/DeleteProjectModal.tsx
+++ b/ui/src/components/DeleteProjectModal.tsx
@@ -13,11 +13,11 @@ type Props = {
 export function DeleteProjectModal({ isOpen, onClose }: Props) {
   const { projectSlug = '' } = useUrlState();
   const { data: project } = useProject(projectSlug);
-  const { mutate: deleteProject } = useDeleteProject();
+  const { mutate: deleteProject } = useDeleteProject({ projectSlug });
   const navigate = useNavigate();
 
   function handleDeleteProject() {
-    deleteProject(projectSlug);
+    deleteProject();
     navigate(ROUTES.home());
     onClose();
   }

--- a/ui/src/components/DeleteProjectModal.tsx
+++ b/ui/src/components/DeleteProjectModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useUrlState } from '../hooks/useUrlState.ts';
 import { useProject } from '../hooks/useProject.ts';
 import { useDeleteProject } from '../hooks/useDeleteProject.ts';
+import { ROUTES } from '../lib/routes.ts';
 import { ConfirmOrCancelBar } from './Judges/ConfirmOrCancelBar.tsx';
 
 type Props = {
@@ -17,7 +18,7 @@ export function DeleteProjectModal({ isOpen, onClose }: Props) {
 
   function handleDeleteProject() {
     deleteProject(projectSlug);
-    navigate('/');
+    navigate(ROUTES.home());
     onClose();
   }
 

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -17,6 +17,7 @@ import { pluralize } from '../../lib/string.ts';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { useModel } from '../../hooks/useModel.ts';
+import { ROUTES } from '../../lib/routes.ts';
 import { ControlBar } from './ControlBar.tsx';
 
 type ShowMode = 'All' | 'With Votes' | 'Without Votes';
@@ -157,7 +158,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
               <Text>
                 Judged all {nHeadToHeads.toLocaleString()} head-to-head matchups between {modelNames}
               </Text>
-              <Button onClick={() => navigate(`/project/${projectSlug}`)}>View Leaderboard</Button>
+              <Button onClick={() => navigate(ROUTES.leaderboard(projectSlug))}>View Leaderboard</Button>
             </Stack>
           }
         />

--- a/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
+++ b/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
@@ -6,6 +6,7 @@ import { pluralize } from '../../lib/string.ts';
 import { useCreateFineTuningTask } from '../../hooks/useCreateFineTuningTask.ts';
 import { useProject } from '../../hooks/useProject.ts';
 import { useJudges } from '../../hooks/useJudges.ts';
+import { ROUTES } from '../../lib/routes.ts';
 import { ConfirmOrCancelBar } from './ConfirmOrCancelBar.tsx';
 import { ConfigureSystemPromptCollapse } from './ConfigureSystemPromptCollapse.tsx';
 
@@ -48,7 +49,7 @@ export function CreateFineTunedJudgeModal({ isOpen, onClose }: Props) {
       <Stack>
         <Text size="sm">
           Start a <b>fine-tuning job</b> to create a custom judge model using the {pluralize(nVotes, 'manual vote')}{' '}
-          submitted on the <Anchor href={`/project/${projectSlug}/compare`}>Head-to-Head</Anchor> tab within the{' '}
+          submitted on the <Anchor href={ROUTES.compare(projectSlug)}>Head-to-Head</Anchor> tab within the{' '}
           <Code>{project?.slug}</Code> project.
         </Text>
         <Select

--- a/ui/src/components/Judges/DeleteJudgeButton.tsx
+++ b/ui/src/components/Judges/DeleteJudgeButton.tsx
@@ -12,10 +12,10 @@ type Props = {
 export function DeleteJudgeButton({ judge }: Props) {
   const { projectSlug = '' } = useUrlState();
   const [isOpen, { toggle, close }] = useDisclosure(false);
-  const { mutate: deleteJudge } = useDeleteJudge({ projectSlug });
+  const { mutate: deleteJudge } = useDeleteJudge({ projectSlug, judgeId: judge.id });
 
   function handleDelete() {
-    deleteJudge(judge.id);
+    deleteJudge();
     close();
   }
 

--- a/ui/src/components/Leaderboard/ExpandedModelDetails.tsx
+++ b/ui/src/components/Leaderboard/ExpandedModelDetails.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { IconDownload, IconGavel } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { DeleteModelButton } from '../DeleteModelButton.tsx';
-import { getProjectApiUrl } from '../../lib/routes.ts';
+import { API_ROUTES } from '../../lib/routes.ts';
 import { useModelHeadToHeadStatsByJudge } from '../../hooks/useModelHeadToHeadStatsByJudge.ts';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { useTriggerModelAutoJudge } from '../../hooks/useTriggerModelAutoJudge.ts';
@@ -54,12 +54,12 @@ export function ExpandedModelDetails({ model }: Props) {
           </Group>
         </Stack>
         <Group gap="xs">
-          <Anchor href={`${getProjectApiUrl(projectSlug)}/model/${model.id}/download/responses`} target="_blank">
+          <Anchor href={API_ROUTES.downloadModelResponsesCsv(projectSlug, model.id)} target="_blank">
             <Button color="teal" variant="light" size="xs" leftSection={<IconDownload size={20} />}>
               Download Response CSV
             </Button>
           </Anchor>
-          <Anchor href={`${getProjectApiUrl(projectSlug)}/model/${model.id}/download/head-to-heads`} target="_blank">
+          <Anchor href={API_ROUTES.downloadModelHeadToHeadsCsv(projectSlug, model.id)} target="_blank">
             <Button color="teal" variant="light" size="xs" leftSection={<IconDownload size={20} />}>
               Download Head-to-Head CSV
             </Button>

--- a/ui/src/components/Leaderboard/ExpandedModelDetails.tsx
+++ b/ui/src/components/Leaderboard/ExpandedModelDetails.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { IconDownload, IconGavel } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { DeleteModelButton } from '../DeleteModelButton.tsx';
-import { getProjectUrl } from '../../lib/routes.ts';
+import { getProjectApiUrl } from '../../lib/routes.ts';
 import { useModelHeadToHeadStatsByJudge } from '../../hooks/useModelHeadToHeadStatsByJudge.ts';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { useTriggerModelAutoJudge } from '../../hooks/useTriggerModelAutoJudge.ts';
@@ -54,12 +54,12 @@ export function ExpandedModelDetails({ model }: Props) {
           </Group>
         </Stack>
         <Group gap="xs">
-          <Anchor href={`${getProjectUrl(projectSlug)}/model/${model.id}/download/responses`} target="_blank">
+          <Anchor href={`${getProjectApiUrl(projectSlug)}/model/${model.id}/download/responses`} target="_blank">
             <Button color="teal" variant="light" size="xs" leftSection={<IconDownload size={20} />}>
               Download Response CSV
             </Button>
           </Anchor>
-          <Anchor href={`${getProjectUrl(projectSlug)}/model/${model.id}/download/head-to-heads`} target="_blank">
+          <Anchor href={`${getProjectApiUrl(projectSlug)}/model/${model.id}/download/head-to-heads`} target="_blank">
             <Button color="teal" variant="light" size="xs" leftSection={<IconDownload size={20} />}>
               Download Head-to-Head CSV
             </Button>

--- a/ui/src/components/Leaderboard/ExploreSelectedModels.tsx
+++ b/ui/src/components/Leaderboard/ExploreSelectedModels.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Portal, Stack, Text } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
 import { useUrlState } from '../../hooks/useUrlState.ts';
+import { ROUTES } from '../../lib/routes.ts';
 import { RankedModel } from './types.ts';
 
 type Props = {
@@ -23,7 +24,7 @@ export function ExploreSelectedModels({ selectedModels }: Props) {
     if (modelB != null) {
       params.append('modelB', String(modelB.id));
     }
-    navigate(`/project/${projectSlug}/compare?${params}`);
+    navigate(`${ROUTES.compare(projectSlug)}?${params}`);
   }
 
   return (

--- a/ui/src/components/Leaderboard/HeadToHeadStatsPlot.tsx
+++ b/ui/src/components/Leaderboard/HeadToHeadStatsPlot.tsx
@@ -8,6 +8,7 @@ import { useUrlState } from '../../hooks/useUrlState.ts';
 import { useModelHeadToHeadStatsByJudge } from '../../hooks/useModelHeadToHeadStatsByJudge.ts';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { useJudge } from '../../hooks/useJudge.ts';
+import { ROUTES } from '../../lib/routes.ts';
 
 type ChartRecord = {
   opponentName: string;
@@ -58,7 +59,7 @@ export function HeadToHeadStatsPlot({ modelId }: Props) {
   );
 
   function handleBarClick({ opponentId }: ChartRecord) {
-    navigate(`/project/${projectSlug}/compare?modelA=${modelId}&modelB=${opponentId}`);
+    navigate(`${ROUTES.compare(projectSlug)}?modelA=${modelId}&modelB=${opponentId}`);
   }
 
   const isDisabled = plotStats.length == 0;

--- a/ui/src/components/Leaderboard/HeadToHeadStatsTable.tsx
+++ b/ui/src/components/Leaderboard/HeadToHeadStatsTable.tsx
@@ -7,6 +7,7 @@ import { ModelHeadToHeadStats } from '../../hooks/useModelHeadToHeadStats.ts';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { useModelHeadToHeadStatsByJudge } from '../../hooks/useModelHeadToHeadStatsByJudge.ts';
 import { usePagination } from '../../hooks/usePagination.ts';
+import { ROUTES } from '../../lib/routes.ts';
 
 type H2hStatsRecord = ModelHeadToHeadStats & {
   unique_id: string;
@@ -101,7 +102,7 @@ export function HeadToHeadStatsTable({ modelId }: Props) {
         minHeight={statsRecords.length === 0 ? 180 : undefined}
         highlightOnHover
         onRowClick={({ record: { other_model_id } }) => {
-          navigate(`/project/${projectSlug}/compare?modelA=${modelId}&modelB=${other_model_id}`);
+          navigate(`${ROUTES.compare(projectSlug)}?modelA=${modelId}&modelB=${other_model_id}`);
         }}
         page={pageNumber}
         onPageChange={setPageNumber}

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -7,6 +7,7 @@ import {
   IconHome,
   IconLogout,
   IconStack2Filled,
+  IconUser,
 } from '@tabler/icons-react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useAppMode } from '../hooks/useAppMode.ts';
@@ -14,7 +15,7 @@ import { ExternalUrls } from '../lib/urls.ts';
 import { ROUTES } from '../lib/routes.ts';
 
 export function MainMenu() {
-  const { logout } = useAuth0();
+  const { user, logout } = useAuth0();
   const { isCloudMode } = useAppMode();
 
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
@@ -48,6 +49,7 @@ export function MainMenu() {
         {isCloudMode && (
           <>
             <Menu.Divider />
+            {user != null && <Menu.Item leftSection={<IconUser {...iconProps} />}>{user.email}</Menu.Item>}
             <Menu.Item
               leftSection={<IconLogout {...iconProps} />}
               onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Group, Menu, Text, Tooltip } from '@mantine/core';
+import { Anchor, Group, Menu, Stack, Text, Tooltip } from '@mantine/core';
 import {
   IconBeta,
   IconBrandGithub,
@@ -14,7 +14,7 @@ import { ExternalUrls } from '../lib/urls.ts';
 import { ROUTES } from '../lib/routes.ts';
 
 export function MainMenu() {
-  const { logout } = useAuth0();
+  const { user, logout } = useAuth0();
   const { isCloudMode } = useAppMode();
 
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
@@ -52,7 +52,14 @@ export function MainMenu() {
               leftSection={<IconLogout {...iconProps} />}
               onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
             >
-              Sign Out
+              <Stack gap={0}>
+                <Text inherit>Sign Out</Text>
+                {user != null && (
+                  <Text size="xs" c="dimmed">
+                    {user.email}
+                  </Text>
+                )}
+              </Stack>
             </Menu.Item>
           </>
         )}

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -8,12 +8,16 @@ import {
   IconLogout,
   IconStack2Filled,
 } from '@tabler/icons-react';
+import { useAuth0 } from '@auth0/auth0-react';
 import { useAppMode } from '../hooks/useAppMode.ts';
 import { ExternalUrls } from '../lib/urls.ts';
+import { ROUTES } from '../lib/routes.ts';
 
 export function MainMenu() {
-  const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
+  const { logout } = useAuth0();
   const { isCloudMode } = useAppMode();
+
+  const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
   return (
     <Menu>
       <Menu.Target>
@@ -29,7 +33,7 @@ export function MainMenu() {
       </Menu.Target>
 
       <Menu.Dropdown>
-        <Anchor href="/" underline="never">
+        <Anchor href={ROUTES.home()} underline="never">
           <Menu.Item leftSection={<IconHome {...iconProps} />}>Home</Menu.Item>
         </Anchor>
         <Anchor href={ExternalUrls.AUTOARENA_GITHUB} underline="never" target="_blank">
@@ -44,9 +48,12 @@ export function MainMenu() {
         {isCloudMode && (
           <>
             <Menu.Divider />
-            <Anchor href="/" /* TODO: logout URL */ underline="never">
-              <Menu.Item leftSection={<IconLogout {...iconProps} />}>Log out</Menu.Item>
-            </Anchor>
+            <Menu.Item
+              leftSection={<IconLogout {...iconProps} />}
+              onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+            >
+              Sign Out
+            </Menu.Item>
           </>
         )}
       </Menu.Dropdown>

--- a/ui/src/components/OnboardingTimeline.tsx
+++ b/ui/src/components/OnboardingTimeline.tsx
@@ -10,6 +10,7 @@ import { Model, useModels } from '../hooks/useModels.ts';
 import { useOnboardingGuideDismissed } from '../hooks/useOnboardingGuideDismissed.ts';
 import { useProject } from '../hooks/useProject.ts';
 import { useProjects } from '../hooks/useProjects.ts';
+import { ROUTES } from '../lib/routes.ts';
 import { AddModelButton } from './AddModelButton.tsx';
 import { CreateProjectButton } from './CreateProjectButton.tsx';
 import { ProjectSelect } from './ProjectSelect.tsx';
@@ -153,7 +154,7 @@ export function OnboardingTimeline({ dismissable = true }: Props) {
                 timestamp={firstJudge?.created}
                 action={
                   activeStage === 1 ? (
-                    <Anchor href={`/project/${projectSlug}/judges`}>
+                    <Anchor href={ROUTES.judges(projectSlug)}>
                       <Button leftSection={<IconGavel size={18} />} size="xs">
                         Configure Judge
                       </Button>

--- a/ui/src/components/OnboardingTimeline.tsx
+++ b/ui/src/components/OnboardingTimeline.tsx
@@ -154,7 +154,7 @@ export function OnboardingTimeline({ dismissable = true }: Props) {
                 timestamp={firstJudge?.created}
                 action={
                   activeStage === 1 ? (
-                    <Anchor href={ROUTES.judges(projectSlug)}>
+                    <Anchor href={ROUTES.judges(projectSlug ?? '')}>
                       <Button leftSection={<IconGavel size={18} />} size="xs">
                         Configure Judge
                       </Button>

--- a/ui/src/components/Page.tsx
+++ b/ui/src/components/Page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { notifications } from '@mantine/notifications';
 import { useUrlState } from '../hooks/useUrlState.ts';
 import { useProject } from '../hooks/useProject.ts';
+import { ROUTES } from '../lib/routes.ts';
 import { HeadToHead } from './HeadToHead/HeadToHead.tsx';
 import { Leaderboard } from './Leaderboard/Leaderboard.tsx';
 import { Judges } from './Judges/Judges.tsx';
@@ -36,21 +37,20 @@ export function Page({ tab }: Props) {
         color: 'red',
         key: 'project-not-found',
       });
-      navigate('/');
+      navigate(ROUTES.home());
     }
   }, [project, isLoadingProject]);
 
   function setTab(newTab: string | null) {
-    const baseUrl = `/project/${projectSlug}`;
     switch (newTab) {
       case TAB_LEADERBOARD:
-        navigate(baseUrl);
+        navigate(ROUTES.leaderboard(projectSlug ?? ''));
         break;
       case TAB_COMPARISON:
-        navigate(`${baseUrl}/compare`);
+        navigate(ROUTES.compare(projectSlug ?? ''));
         break;
       case TAB_JUDGES:
-        navigate(`${baseUrl}/judges`);
+        navigate(ROUTES.judges(projectSlug ?? ''));
         break;
     }
   }

--- a/ui/src/components/TasksDrawer/TasksDrawer.tsx
+++ b/ui/src/components/TasksDrawer/TasksDrawer.tsx
@@ -10,7 +10,7 @@ import { pluralize } from '../../lib/string.ts';
 import { getModelsQueryKey } from '../../hooks/useModels.ts';
 import { useClearCompletedTasks } from '../../hooks/useClearCompletedTasks.ts';
 import { taskIsDone } from '../../lib/tasks.ts';
-import { getProjectUrl } from '../../lib/routes.ts';
+import { getProjectApiUrl } from '../../lib/routes.ts';
 import { getJudgesQueryKey } from '../../hooks/useJudges.ts';
 import { useHasActiveTasksStream } from '../../hooks/useHasActiveTasksStream.ts';
 import { NonIdealState } from '../NonIdealState.tsx';
@@ -37,7 +37,7 @@ export function TasksDrawer() {
   useEffect(() => {
     queryClient.invalidateQueries({ queryKey: getModelsQueryKey(projectSlug ?? '') });
     queryClient.invalidateQueries({ queryKey: getJudgesQueryKey(projectSlug ?? '') });
-    queryClient.invalidateQueries({ queryKey: [getProjectUrl(projectSlug ?? ''), '/model'] });
+    queryClient.invalidateQueries({ queryKey: [getProjectApiUrl(projectSlug ?? ''), '/model'] });
   }, [tasksCompleted.length]);
 
   return (

--- a/ui/src/hooks/useCanAccessJudgeType.ts
+++ b/ui/src/hooks/useCanAccessJudgeType.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { JudgeType } from '../components/Judges/types.ts';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 function getCanAccessJudgeTypeQueryKey(projectSlug: string, judgeType?: JudgeType) {
-  return [getProjectUrl(projectSlug), '/judge', judgeType, 'can-access'];
+  return [getProjectApiUrl(projectSlug), '/judge', judgeType, 'can-access'];
 }
 
 type Params = {
@@ -14,7 +14,7 @@ export function useCanAccessJudgeType({ projectSlug, judgeType }: Params) {
   return useQuery({
     queryKey: getCanAccessJudgeTypeQueryKey(projectSlug, judgeType),
     queryFn: async () => {
-      const url = `${getProjectUrl(projectSlug)}/judge/${judgeType}/can-access`;
+      const url = `${getProjectApiUrl(projectSlug)}/judge/${judgeType}/can-access`;
       const response = await fetch(url);
       if (!response.ok) {
         return;

--- a/ui/src/hooks/useCanAccessJudgeType.ts
+++ b/ui/src/hooks/useCanAccessJudgeType.ts
@@ -1,23 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { JudgeType } from '../components/Judges/types.ts';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-function getCanAccessJudgeTypeQueryKey(projectSlug: string, judgeType?: JudgeType) {
-  return [getProjectApiUrl(projectSlug), '/judge', judgeType, 'can-access'];
-}
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 type Params = {
   projectSlug: string;
   judgeType?: JudgeType;
 };
 export function useCanAccessJudgeType({ projectSlug, judgeType }: Params) {
+  const url = API_ROUTES.checkCanAccess(projectSlug, judgeType ?? 'unrecognized');
   return useQuery({
-    queryKey: getCanAccessJudgeTypeQueryKey(projectSlug, judgeType),
+    queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug)}/judge/${judgeType}/can-access`;
       const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to check judge type availability');
       }
       const result: boolean = await response.json();
       return result;

--- a/ui/src/hooks/useClearCompletedTasks.ts
+++ b/ui/src/hooks/useClearCompletedTasks.ts
@@ -1,10 +1,6 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
-
-function getClearCompletedTasksQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/tasks', 'DELETE'];
-}
 
 type Params = {
   projectSlug?: string;
@@ -12,11 +8,14 @@ type Params = {
 };
 export function useClearCompletedTasks({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.deleteCompletedTasks(projectSlug ?? '');
   return useMutation({
-    mutationKey: getClearCompletedTasksQueryKey(projectSlug ?? ''),
+    mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug ?? '')}/tasks/completed`;
-      await fetch(url, { method: 'DELETE' });
+      const response = await fetch(url, { method: 'DELETE' });
+      if (!response.ok) {
+        throw new Error('Failed to clear completed tasks');
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: getTasksQueryKey(projectSlug ?? '') });

--- a/ui/src/hooks/useClearCompletedTasks.ts
+++ b/ui/src/hooks/useClearCompletedTasks.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
 
 function getClearCompletedTasksQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/tasks', 'DELETE'];
+  return [getProjectApiUrl(projectSlug), '/tasks', 'DELETE'];
 }
 
 type Params = {
@@ -15,7 +15,7 @@ export function useClearCompletedTasks({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getClearCompletedTasksQueryKey(projectSlug ?? ''),
     mutationFn: async () => {
-      const url = `${getProjectUrl(projectSlug ?? '')}/tasks/completed`;
+      const url = `${getProjectApiUrl(projectSlug ?? '')}/tasks/completed`;
       await fetch(url, { method: 'DELETE' });
     },
     onSettled: () => {

--- a/ui/src/hooks/useCreateFineTuningTask.ts
+++ b/ui/src/hooks/useCreateFineTuningTask.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
 
 function getCreateFineTuningTaskQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/fine-tune'];
+  return [getProjectApiUrl(projectSlug), '/fine-tune'];
 }
 
 type CreateFineTuningTaskRequest = {
@@ -21,7 +21,7 @@ export function useCreateFineTuningTask({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getCreateFineTuningTaskQueryKey(projectSlug),
     mutationFn: async (request: CreateFineTuningTaskRequest) => {
-      const url = `${getProjectUrl(projectSlug)}/${projectSlug}`;
+      const url = `${getProjectApiUrl(projectSlug)}/${projectSlug}`;
       const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(request),

--- a/ui/src/hooks/useCreateFineTuningTask.ts
+++ b/ui/src/hooks/useCreateFineTuningTask.ts
@@ -1,11 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
-
-function getCreateFineTuningTaskQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/fine-tune'];
-}
 
 type CreateFineTuningTaskRequest = {
   base_model: string;
@@ -18,10 +14,10 @@ type Params = {
 };
 export function useCreateFineTuningTask({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.createFineTuningTask(projectSlug);
   return useMutation({
-    mutationKey: getCreateFineTuningTaskQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: CreateFineTuningTaskRequest) => {
-      const url = `${getProjectApiUrl(projectSlug)}/${projectSlug}`;
       const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(request),

--- a/ui/src/hooks/useCreateJudge.ts
+++ b/ui/src/hooks/useCreateJudge.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { JudgeType } from '../components/Judges/types.ts';
-import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
 
 type CreateJudgeRequest = {

--- a/ui/src/hooks/useCreateJudge.ts
+++ b/ui/src/hooks/useCreateJudge.ts
@@ -1,12 +1,8 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { JudgeType } from '../components/Judges/types.ts';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
-
-function getCreateJudgeQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/judge', 'POST'];
-}
 
 type CreateJudgeRequest = {
   judge_type: JudgeType;
@@ -22,10 +18,11 @@ type Params = {
 };
 export function useCreateJudge({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.createJudge(projectSlug);
   return useMutation({
-    mutationKey: getCreateJudgeQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(projectSlug, 'POST'),
     mutationFn: async (request: CreateJudgeRequest) => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge`, {
+      const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useCreateJudge.ts
+++ b/ui/src/hooks/useCreateJudge.ts
@@ -20,7 +20,7 @@ export function useCreateJudge({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
   const url = API_ROUTES.createJudge(projectSlug);
   return useMutation({
-    mutationKey: urlAsQueryKey(projectSlug, 'POST'),
+    mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: CreateJudgeRequest) => {
       const response = await fetch(url, {
         method: 'POST',

--- a/ui/src/hooks/useCreateJudge.ts
+++ b/ui/src/hooks/useCreateJudge.ts
@@ -1,11 +1,11 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { JudgeType } from '../components/Judges/types.ts';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
 
 function getCreateJudgeQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/judge', 'POST'];
+  return [getProjectApiUrl(projectSlug), '/judge', 'POST'];
 }
 
 type CreateJudgeRequest = {
@@ -25,7 +25,7 @@ export function useCreateJudge({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getCreateJudgeQueryKey(projectSlug),
     mutationFn: async (request: CreateJudgeRequest) => {
-      const response = await fetch(`${getProjectUrl(projectSlug)}/judge`, {
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge`, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useCreateProject.ts
+++ b/ui/src/hooks/useCreateProject.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
-import { getBaseUrl } from '../lib/routes.ts';
+import { getBaseApiUrl, ROUTES } from '../lib/routes.ts';
 import { Project, PROJECTS_QUERY_KEY } from './useProjects.ts';
 
 type CreateProjectRequest = {
@@ -14,9 +14,9 @@ export function useCreateProject({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationKey: [`${getBaseUrl()}/project`],
+    mutationKey: [`${getBaseApiUrl()}/project`],
     mutationFn: async (request: CreateProjectRequest) => {
-      const response = await fetch(`${getBaseUrl()}/project`, {
+      const response = await fetch(`${getBaseApiUrl()}/project`, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },
@@ -30,7 +30,7 @@ export function useCreateProject({
         message: `Switched to newly created project '${project.slug}'`,
         color: 'green',
       });
-      navigate(`/project/${project.slug}`);
+      navigate(ROUTES.leaderboard(project.slug));
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: PROJECTS_QUERY_KEY });

--- a/ui/src/hooks/useCreateProject.ts
+++ b/ui/src/hooks/useCreateProject.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
-import {API_ROUTES, getBaseApiUrl, ROUTES, urlAsQueryKey} from '../lib/routes.ts';
+import { API_ROUTES, ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getProjectsQueryKey, Project } from './useProjects.ts';
 
 type CreateProjectRequest = {

--- a/ui/src/hooks/useCreateProject.ts
+++ b/ui/src/hooks/useCreateProject.ts
@@ -1,8 +1,8 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
-import { getBaseApiUrl, ROUTES } from '../lib/routes.ts';
-import { Project, PROJECTS_QUERY_KEY } from './useProjects.ts';
+import {API_ROUTES, getBaseApiUrl, ROUTES, urlAsQueryKey} from '../lib/routes.ts';
+import { getProjectsQueryKey, Project } from './useProjects.ts';
 
 type CreateProjectRequest = {
   name: string;
@@ -13,14 +13,18 @@ export function useCreateProject({
 }: { options?: UseMutationOptions<Project, Error, CreateProjectRequest> } = {}) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const url = API_ROUTES.createProject();
   return useMutation({
-    mutationKey: [`${getBaseApiUrl()}/project`],
+    mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async (request: CreateProjectRequest) => {
-      const response = await fetch(`${getBaseApiUrl()}/project`, {
+      const response = await fetch(url, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },
       });
+      if (!response.ok) {
+        throw new Error('Failed to create project');
+      }
       const result: Project = await response.json();
       return result;
     },
@@ -33,7 +37,7 @@ export function useCreateProject({
       navigate(ROUTES.leaderboard(project.slug));
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: PROJECTS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: getProjectsQueryKey() });
     },
     ...options,
   });

--- a/ui/src/hooks/useDeleteJudge.ts
+++ b/ui/src/hooks/useDeleteJudge.ts
@@ -7,7 +7,7 @@ import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 type Params = {
   projectSlug: string;
   judgeId: number;
-  options?: UseMutationOptions<void, Error, number>;
+  options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteJudge({ projectSlug, judgeId, options = {} }: Params) {
   const queryClient = useQueryClient();

--- a/ui/src/hooks/useDeleteJudge.ts
+++ b/ui/src/hooks/useDeleteJudge.ts
@@ -1,12 +1,8 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
 import { getJudgesQueryKey } from './useJudges.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
-
-function getDeleteJudgeQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/judge', 'DELETE'];
-}
 
 type Params = {
   projectSlug: string;
@@ -14,11 +10,14 @@ type Params = {
 };
 export function useDeleteJudge({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.deleteJudge(projectSlug);
   return useMutation({
-    mutationKey: getDeleteJudgeQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async (judgeId: number) => {
-      const url = `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`;
-      await fetch(url, { method: 'DELETE' });
+      const response= await fetch(url, { method: 'DELETE' });
+      if (!response.ok) {
+        throw new Error('Failed to delete judge')
+      }
     },
     onError: () => {
       notifications.show({

--- a/ui/src/hooks/useDeleteJudge.ts
+++ b/ui/src/hooks/useDeleteJudge.ts
@@ -1,11 +1,11 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getJudgesQueryKey } from './useJudges.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 
 function getDeleteJudgeQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/judge', 'DELETE'];
+  return [getProjectApiUrl(projectSlug), '/judge', 'DELETE'];
 }
 
 type Params = {
@@ -17,7 +17,7 @@ export function useDeleteJudge({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getDeleteJudgeQueryKey(projectSlug),
     mutationFn: async (judgeId: number) => {
-      const url = `${getProjectUrl(projectSlug)}/judge/${judgeId}`;
+      const url = `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`;
       await fetch(url, { method: 'DELETE' });
     },
     onError: () => {

--- a/ui/src/hooks/useDeleteJudge.ts
+++ b/ui/src/hooks/useDeleteJudge.ts
@@ -1,22 +1,23 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey } from './useJudges.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 
 type Params = {
   projectSlug: string;
+  judgeId: number;
   options?: UseMutationOptions<void, Error, number>;
 };
-export function useDeleteJudge({ projectSlug, options = {} }: Params) {
+export function useDeleteJudge({ projectSlug, judgeId, options = {} }: Params) {
   const queryClient = useQueryClient();
-  const url = API_ROUTES.deleteJudge(projectSlug);
+  const url = API_ROUTES.deleteJudge(projectSlug, judgeId);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'DELETE'),
-    mutationFn: async (judgeId: number) => {
-      const response= await fetch(url, { method: 'DELETE' });
+    mutationFn: async () => {
+      const response = await fetch(url, { method: 'DELETE' });
       if (!response.ok) {
-        throw new Error('Failed to delete judge')
+        throw new Error('Failed to delete judge');
       }
     },
     onError: () => {

--- a/ui/src/hooks/useDeleteModel.ts
+++ b/ui/src/hooks/useDeleteModel.ts
@@ -1,24 +1,24 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 
-function getDeleteModelQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/model', 'DELETE'];
-}
-
 type Params = {
   projectSlug: string;
+  modelId: number;
   options?: UseMutationOptions<void, Error, number>;
 };
-export function useDeleteModel({ projectSlug, options = {} }: Params) {
+export function useDeleteModel({ projectSlug, modelId, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.deleteModel(projectSlug, modelId);
   return useMutation({
-    mutationKey: getDeleteModelQueryKey(projectSlug),
-    mutationFn: async (modelId: number) => {
-      const url = `${getProjectApiUrl(projectSlug)}/model/${modelId}`;
-      await fetch(url, { method: 'DELETE' });
+    mutationKey: urlAsQueryKey(url, 'DELETE'),
+    mutationFn: async () => {
+      const response = await fetch(url, { method: 'DELETE' });
+      if (!response.ok) {
+        throw new Error('Failed to delete model');
+      }
     },
     onError: () => {
       notifications.show({

--- a/ui/src/hooks/useDeleteModel.ts
+++ b/ui/src/hooks/useDeleteModel.ts
@@ -7,7 +7,7 @@ import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 type Params = {
   projectSlug: string;
   modelId: number;
-  options?: UseMutationOptions<void, Error, number>;
+  options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteModel({ projectSlug, modelId, options = {} }: Params) {
   const queryClient = useQueryClient();

--- a/ui/src/hooks/useDeleteModel.ts
+++ b/ui/src/hooks/useDeleteModel.ts
@@ -1,11 +1,11 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
 
 function getDeleteModelQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/model', 'DELETE'];
+  return [getProjectApiUrl(projectSlug), '/model', 'DELETE'];
 }
 
 type Params = {
@@ -17,7 +17,7 @@ export function useDeleteModel({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getDeleteModelQueryKey(projectSlug),
     mutationFn: async (modelId: number) => {
-      const url = `${getProjectUrl(projectSlug)}/model/${modelId}`;
+      const url = `${getProjectApiUrl(projectSlug)}/model/${modelId}`;
       await fetch(url, { method: 'DELETE' });
     },
     onError: () => {

--- a/ui/src/hooks/useDeleteProject.ts
+++ b/ui/src/hooks/useDeleteProject.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { getBaseApiUrl, getProjectApiUrl } from '../lib/routes.ts';
-import { PROJECTS_QUERY_KEY } from './useProjects.ts';
+import { getProjectsQueryKey } from './useProjects.ts';
 
 function getDeleteProjectQueryKey() {
   return [`${getBaseApiUrl()}/project`, 'DELETE'];
@@ -26,7 +26,7 @@ export function useDeleteProject({ options }: Params = {}) {
       });
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: PROJECTS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: getProjectsQueryKey() });
     },
     ...options,
   });

--- a/ui/src/hooks/useDeleteProject.ts
+++ b/ui/src/hooks/useDeleteProject.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getBaseUrl, getProjectUrl } from '../lib/routes.ts';
+import { getBaseApiUrl, getProjectApiUrl } from '../lib/routes.ts';
 import { PROJECTS_QUERY_KEY } from './useProjects.ts';
 
 function getDeleteProjectQueryKey() {
-  return [`${getBaseUrl()}/project`, 'DELETE'];
+  return [`${getBaseApiUrl()}/project`, 'DELETE'];
 }
 
 type Params = {
@@ -15,7 +15,7 @@ export function useDeleteProject({ options }: Params = {}) {
   return useMutation({
     mutationKey: getDeleteProjectQueryKey(),
     mutationFn: async (projectSlug: string) => {
-      const url = getProjectUrl(projectSlug);
+      const url = getProjectApiUrl(projectSlug);
       await fetch(url, { method: 'DELETE' });
     },
     onError: () => {

--- a/ui/src/hooks/useDeleteProject.ts
+++ b/ui/src/hooks/useDeleteProject.ts
@@ -1,6 +1,6 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getBaseApiUrl, getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, getBaseApiUrl } from '../lib/routes.ts';
 import { getProjectsQueryKey } from './useProjects.ts';
 
 function getDeleteProjectQueryKey() {
@@ -8,15 +8,19 @@ function getDeleteProjectQueryKey() {
 }
 
 type Params = {
+  projectSlug: string;
   options?: UseMutationOptions<void, Error, string>;
 };
-export function useDeleteProject({ options }: Params = {}) {
+export function useDeleteProject({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.deleteProject(projectSlug);
   return useMutation({
     mutationKey: getDeleteProjectQueryKey(),
-    mutationFn: async (projectSlug: string) => {
-      const url = getProjectApiUrl(projectSlug);
-      await fetch(url, { method: 'DELETE' });
+    mutationFn: async () => {
+      const response = await fetch(url, { method: 'DELETE' });
+      if (!response.ok) {
+        throw new Error('Failed to delete project');
+      }
     },
     onError: () => {
       notifications.show({

--- a/ui/src/hooks/useDeleteProject.ts
+++ b/ui/src/hooks/useDeleteProject.ts
@@ -1,21 +1,17 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { API_ROUTES, getBaseApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getProjectsQueryKey } from './useProjects.ts';
-
-function getDeleteProjectQueryKey() {
-  return [`${getBaseApiUrl()}/project`, 'DELETE'];
-}
 
 type Params = {
   projectSlug: string;
-  options?: UseMutationOptions<void, Error, string>;
+  options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteProject({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
   const url = API_ROUTES.deleteProject(projectSlug);
   return useMutation({
-    mutationKey: getDeleteProjectQueryKey(),
+    mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
       const response = await fetch(url, { method: 'DELETE' });
       if (!response.ok) {

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -1,9 +1,9 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 function getHasActiveTasksQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/tasks', '/has-active'];
+  return [getProjectApiUrl(projectSlug), '/tasks', '/has-active'];
 }
 
 export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<boolean, Error> {
@@ -13,7 +13,7 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
-      await fetchEventSource(`${getProjectUrl(projectSlug ?? '')}/tasks/has-active`, {
+      await fetchEventSource(`${getProjectApiUrl(projectSlug ?? '')}/tasks/has-active`, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -1,19 +1,16 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-function getHasActiveTasksQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/tasks', '/has-active'];
-}
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<boolean, Error> {
   const queryClient = useQueryClient();
-  const queryKey = getHasActiveTasksQueryKey(projectSlug ?? '');
+  const url = API_ROUTES.getHasActiveTasksStream(projectSlug ?? '');
+  const queryKey = urlAsQueryKey(url);
 
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
-      await fetchEventSource(`${getProjectApiUrl(projectSlug ?? '')}/tasks/has-active`, {
+      await fetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useHeadToHeadCount.ts
+++ b/ui/src/hooks/useHeadToHeadCount.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-function getHeadToHeadCountQueryKey(projectSlug?: string) {
-  return [getProjectApiUrl(projectSlug ?? ''), '/head-to-head', '/count'];
-}
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export function useHeadToHeadCount(projectSlug?: string) {
+  const url = API_ROUTES.getHeadToHeadCount(projectSlug ?? '');
   return useQuery({
-    queryKey: getHeadToHeadCountQueryKey(projectSlug),
+    queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/head-to-head/count`);
+      const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch head-to-head count');
       }
       const result: number = await response.json();
       return result;

--- a/ui/src/hooks/useHeadToHeadCount.ts
+++ b/ui/src/hooks/useHeadToHeadCount.ts
@@ -1,15 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 function getHeadToHeadCountQueryKey(projectSlug?: string) {
-  return [getProjectUrl(projectSlug ?? ''), '/head-to-head', '/count'];
+  return [getProjectApiUrl(projectSlug ?? ''), '/head-to-head', '/count'];
 }
 
 export function useHeadToHeadCount(projectSlug?: string) {
   return useQuery({
     queryKey: getHeadToHeadCountQueryKey(projectSlug),
     queryFn: async () => {
-      const response = await fetch(`${getProjectUrl(projectSlug ?? '')}/head-to-head/count`);
+      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/head-to-head/count`);
       if (!response.ok) {
         return;
       }

--- a/ui/src/hooks/useHeadToHeads.ts
+++ b/ui/src/hooks/useHeadToHeads.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 export type HeadToHeadHistoryItem = {
   judge_id: number;
@@ -23,10 +23,10 @@ type Params = {
 };
 export function useHeadToHeads({ projectSlug, modelAId, modelBId }: Params) {
   return useQuery({
-    queryKey: [getProjectUrl(projectSlug), '/head-to-heads', modelAId, modelBId],
+    queryKey: [getProjectApiUrl(projectSlug), '/head-to-heads', modelAId, modelBId],
     queryFn: async () => {
       const body = { model_a_id: modelAId, model_b_id: modelBId };
-      const response = await fetch(`${getProjectUrl(projectSlug)}/head-to-heads`, {
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/head-to-heads`, {
         method: 'PUT',
         body: JSON.stringify(body),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useHeadToHeads.ts
+++ b/ui/src/hooks/useHeadToHeads.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export type HeadToHeadHistoryItem = {
   judge_id: number;
@@ -22,17 +22,18 @@ type Params = {
   modelBId: number;
 };
 export function useHeadToHeads({ projectSlug, modelAId, modelBId }: Params) {
+  const url = API_ROUTES.getHeadToHeads(projectSlug);
   return useQuery({
-    queryKey: [getProjectApiUrl(projectSlug), '/head-to-heads', modelAId, modelBId],
+    queryKey: [...urlAsQueryKey(url), modelAId, modelBId],
     queryFn: async () => {
       const body = { model_a_id: modelAId, model_b_id: modelBId };
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/head-to-heads`, {
+      const response = await fetch(url, {
         method: 'PUT',
         body: JSON.stringify(body),
         headers: { 'Content-Type': 'application/json' },
       });
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch head-to-heads');
       }
       const result: HeadToHead[] = await response.json();
       return result;

--- a/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
+++ b/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export function useJudgeDefaultSystemPrompt(projectSlug: string) {
   const url = API_ROUTES.getDefaultSystemPrompt(projectSlug);

--- a/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
+++ b/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
@@ -1,15 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 function getJudgeDefaultSystemPromptQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/judge/default-system-prompt'];
+  return [getProjectApiUrl(projectSlug), '/judge/default-system-prompt'];
 }
 
 export function useJudgeDefaultSystemPrompt(projectSlug: string) {
   return useQuery({
     queryKey: getJudgeDefaultSystemPromptQueryKey(projectSlug),
     queryFn: async () => {
-      const response = await fetch(`${getProjectUrl(projectSlug)}/judge/default-system-prompt`);
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge/default-system-prompt`);
       if (!response.ok) {
         return;
       }

--- a/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
+++ b/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-function getJudgeDefaultSystemPromptQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/judge/default-system-prompt'];
-}
+import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
 
 export function useJudgeDefaultSystemPrompt(projectSlug: string) {
+  const url = API_ROUTES.getDefaultSystemPrompt(projectSlug);
   return useQuery({
-    queryKey: getJudgeDefaultSystemPromptQueryKey(projectSlug),
+    queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge/default-system-prompt`);
+      const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch default judge system prompt');
       }
       const result: string = await response.json();
       return result;

--- a/ui/src/hooks/useJudges.ts
+++ b/ui/src/hooks/useJudges.ts
@@ -1,4 +1,4 @@
-import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { JudgeType } from '../components/Judges/types.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
@@ -19,7 +19,7 @@ export type Judge = {
 };
 
 export function useJudges(projectSlug: string | undefined) {
-  const url = API_ROUTES.getJudges(projectSlug ?? '')
+  const url = API_ROUTES.getJudges(projectSlug ?? '');
   return useQueryWithErrorToast({
     queryKey: getJudgesQueryKey(projectSlug ?? ''),
     queryFn: async () => {

--- a/ui/src/hooks/useJudges.ts
+++ b/ui/src/hooks/useJudges.ts
@@ -1,9 +1,9 @@
-import { getProjectApiUrl } from '../lib/routes.ts';
+import {API_ROUTES, getProjectApiUrl, urlAsQueryKey} from '../lib/routes.ts';
 import { JudgeType } from '../components/Judges/types.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
 export function getJudgesQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/judges'];
+  return urlAsQueryKey(API_ROUTES.getJudges(projectSlug));
 }
 
 export type Judge = {
@@ -19,13 +19,13 @@ export type Judge = {
 };
 
 export function useJudges(projectSlug: string | undefined) {
+  const url = API_ROUTES.getJudges(projectSlug ?? '')
   return useQueryWithErrorToast({
     queryKey: getJudgesQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug ?? '')}/judges`;
       const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch judges');
       }
       const result: Judge[] = await response.json();
       return result;

--- a/ui/src/hooks/useJudges.ts
+++ b/ui/src/hooks/useJudges.ts
@@ -1,9 +1,9 @@
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { JudgeType } from '../components/Judges/types.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
 export function getJudgesQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/judges'];
+  return [getProjectApiUrl(projectSlug), '/judges'];
 }
 
 export type Judge = {
@@ -22,7 +22,7 @@ export function useJudges(projectSlug: string | undefined) {
   return useQueryWithErrorToast({
     queryKey: getJudgesQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const url = `${getProjectUrl(projectSlug ?? '')}/judges`;
+      const url = `${getProjectApiUrl(projectSlug ?? '')}/judges`;
       const response = await fetch(url);
       if (!response.ok) {
         return;

--- a/ui/src/hooks/useModelHeadToHeadStats.ts
+++ b/ui/src/hooks/useModelHeadToHeadStats.ts
@@ -1,12 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-export function getModelHeadToHeadStatsEndpoint(projectSlug: string, modelId: number) {
-  return `${getProjectApiUrl(projectSlug)}/model/${modelId}/head-to-head/stats`;
-}
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export function getModelHeadToHeadStatsQueryKey(projectSlug: string, modelId?: number) {
-  return [getProjectApiUrl(projectSlug), '/model', modelId, '/head-to-head/stats'];
+  return urlAsQueryKey(API_ROUTES.getHeadToHeadStats(projectSlug, modelId ?? -1));
 }
 
 export type ModelHeadToHeadStats = {
@@ -24,13 +20,13 @@ type Params = {
   modelId?: number;
 };
 export function useModelHeadToHeadStats({ projectSlug, modelId }: Params) {
+  const url = API_ROUTES.getHeadToHeadStats(projectSlug ?? '', modelId ?? -1);
   return useQuery({
     queryKey: getModelHeadToHeadStatsQueryKey(projectSlug ?? '', modelId),
     queryFn: async () => {
-      const url = getModelHeadToHeadStatsEndpoint(projectSlug ?? '', modelId ?? -1);
       const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch head-to-head stats');
       }
       const result: ModelHeadToHeadStats[] = await response.json();
       return result;

--- a/ui/src/hooks/useModelHeadToHeadStats.ts
+++ b/ui/src/hooks/useModelHeadToHeadStats.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 export function getModelHeadToHeadStatsEndpoint(projectSlug: string, modelId: number) {
-  return `${getProjectUrl(projectSlug)}/model/${modelId}/head-to-head/stats`;
+  return `${getProjectApiUrl(projectSlug)}/model/${modelId}/head-to-head/stats`;
 }
 
 export function getModelHeadToHeadStatsQueryKey(projectSlug: string, modelId?: number) {
-  return [getProjectUrl(projectSlug), '/model', modelId, '/head-to-head/stats'];
+  return [getProjectApiUrl(projectSlug), '/model', modelId, '/head-to-head/stats'];
 }
 
 export type ModelHeadToHeadStats = {

--- a/ui/src/hooks/useModelResponses.ts
+++ b/ui/src/hooks/useModelResponses.ts
@@ -1,9 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
-
-export function getModelResponsesQueryKey(projectSlug: string, modelId: number) {
-  return [getProjectApiUrl(projectSlug), '/model', modelId, '/responses'];
-}
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export type ModelResponse = {
   prompt: string;
@@ -15,13 +11,13 @@ type Params = {
   modelId?: number;
 };
 export function useModelResponses({ projectSlug, modelId }: Params) {
+  const url = API_ROUTES.getModelResponses(projectSlug ?? '', modelId ?? -1);
   return useQuery({
-    queryKey: getModelResponsesQueryKey(projectSlug ?? '', modelId ?? -1),
+    queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug ?? '')}/model/${modelId}/responses`;
       const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch model responses');
       }
       const result: ModelResponse[] = await response.json();
       return result;

--- a/ui/src/hooks/useModelResponses.ts
+++ b/ui/src/hooks/useModelResponses.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 export function getModelResponsesQueryKey(projectSlug: string, modelId: number) {
-  return [getProjectUrl(projectSlug), '/model', modelId, '/responses'];
+  return [getProjectApiUrl(projectSlug), '/model', modelId, '/responses'];
 }
 
 export type ModelResponse = {
@@ -18,7 +18,7 @@ export function useModelResponses({ projectSlug, modelId }: Params) {
   return useQuery({
     queryKey: getModelResponsesQueryKey(projectSlug ?? '', modelId ?? -1),
     queryFn: async () => {
-      const url = `${getProjectUrl(projectSlug ?? '')}/model/${modelId}/responses`;
+      const url = `${getProjectApiUrl(projectSlug ?? '')}/model/${modelId}/responses`;
       const response = await fetch(url);
       if (!response.ok) {
         return;

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -1,8 +1,8 @@
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
 export function getModelsQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/models'];
+  return urlAsQueryKey(API_ROUTES.getModels(projectSlug));
 }
 
 export type Model = {
@@ -17,12 +17,13 @@ export type Model = {
 };
 
 export function useModels(projectSlug: string | undefined) {
+  const url = API_ROUTES.getModels(projectSlug ?? '');
   return useQueryWithErrorToast({
     queryKey: getModelsQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/models`);
+      const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch models');
       }
       const result: Model[] = await response.json();
       return result;

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -1,8 +1,8 @@
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
 export function getModelsQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/models'];
+  return [getProjectApiUrl(projectSlug), '/models'];
 }
 
 export type Model = {
@@ -20,7 +20,7 @@ export function useModels(projectSlug: string | undefined) {
   return useQueryWithErrorToast({
     queryKey: getModelsQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const response = await fetch(`${getProjectUrl(projectSlug ?? '')}/models`);
+      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/models`);
       if (!response.ok) {
         return;
       }

--- a/ui/src/hooks/useModelsRankedByJudge.ts
+++ b/ui/src/hooks/useModelsRankedByJudge.ts
@@ -1,16 +1,16 @@
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 import { Model } from './useModels.ts';
 
 export function getJudgesRankedByModel(projectSlug: string | undefined, judgeId: number | undefined) {
-  return [getProjectUrl(projectSlug ?? ''), '/models', '/by-judge', judgeId];
+  return [getProjectApiUrl(projectSlug ?? ''), '/models', '/by-judge', judgeId];
 }
 
 export function useModelsRankedByJudge(projectSlug: string | undefined, judgeId: number | undefined) {
   return useQueryWithErrorToast({
     queryKey: getJudgesRankedByModel(projectSlug, judgeId),
     queryFn: async () => {
-      const response = await fetch(`${getProjectUrl(projectSlug ?? '')}/models/by-judge/${judgeId}`);
+      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/models/by-judge/${judgeId}`);
       if (!response.ok) {
         return;
       }

--- a/ui/src/hooks/useModelsRankedByJudge.ts
+++ b/ui/src/hooks/useModelsRankedByJudge.ts
@@ -1,18 +1,15 @@
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 import { Model } from './useModels.ts';
 
-export function getJudgesRankedByModel(projectSlug: string | undefined, judgeId: number | undefined) {
-  return [getProjectApiUrl(projectSlug ?? ''), '/models', '/by-judge', judgeId];
-}
-
 export function useModelsRankedByJudge(projectSlug: string | undefined, judgeId: number | undefined) {
+  const url = API_ROUTES.getModelsRankedByJudge(projectSlug ?? '', judgeId ?? -1);
   return useQueryWithErrorToast({
-    queryKey: getJudgesRankedByModel(projectSlug, judgeId),
+    queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug ?? '')}/models/by-judge/${judgeId}`);
+      const response = await fetch(url);
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch models ranked by judge');
       }
       const result: Model[] = await response.json();
       return result;

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -1,8 +1,9 @@
-import { getBaseApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
-const PROJECTS_ENDPOINT = `${getBaseApiUrl()}/projects`;
-export const PROJECTS_QUERY_KEY = [PROJECTS_ENDPOINT];
+export function getProjectsQueryKey() {
+  return urlAsQueryKey(API_ROUTES.getProjects());
+}
 
 export type Project = {
   slug: string;
@@ -12,11 +13,11 @@ export type Project = {
 
 export function useProjects() {
   return useQueryWithErrorToast({
-    queryKey: PROJECTS_QUERY_KEY,
+    queryKey: getProjectsQueryKey(),
     queryFn: async () => {
-      const response = await fetch(PROJECTS_ENDPOINT);
+      const response = await fetch(API_ROUTES.getProjects());
       if (!response.ok) {
-        return;
+        throw new Error('Failed to fetch projects');
       }
       const result: Project[] = await response.json();
       return result;

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -1,7 +1,7 @@
-import { getBaseUrl } from '../lib/routes.ts';
+import { getBaseApiUrl } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 
-const PROJECTS_ENDPOINT = `${getBaseUrl()}/projects`;
+const PROJECTS_ENDPOINT = `${getBaseApiUrl()}/projects`;
 export const PROJECTS_QUERY_KEY = [PROJECTS_ENDPOINT];
 
 export type Project = {

--- a/ui/src/hooks/useRecomputeLeaderboard.ts
+++ b/ui/src/hooks/useRecomputeLeaderboard.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
 
 function getDeleteJudgeQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/elo/reseed-scores'];
+  return [getProjectApiUrl(projectSlug), '/elo/reseed-scores'];
 }
 
 type Params = {
@@ -16,7 +16,7 @@ export function useRecomputeLeaderboard({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getDeleteJudgeQueryKey(projectSlug),
     mutationFn: async () => {
-      const url = `${getProjectUrl(projectSlug)}/elo/reseed-scores`;
+      const url = `${getProjectApiUrl(projectSlug)}/elo/reseed-scores`;
       await fetch(url, { method: 'PUT' });
     },
     onSuccess: () => {

--- a/ui/src/hooks/useRecomputeLeaderboard.ts
+++ b/ui/src/hooks/useRecomputeLeaderboard.ts
@@ -1,11 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
-
-function getDeleteJudgeQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/elo/reseed-scores'];
-}
 
 type Params = {
   projectSlug: string;
@@ -13,11 +9,14 @@ type Params = {
 };
 export function useRecomputeLeaderboard({ projectSlug, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.reseedEloScores(projectSlug);
   return useMutation({
-    mutationKey: getDeleteJudgeQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug)}/elo/reseed-scores`;
-      await fetch(url, { method: 'PUT' });
+      const response = await fetch(url, { method: 'PUT' });
+      if (!response.ok) {
+        throw new Error('Failed to recompute leaderboard rankings');
+      }
     },
     onSuccess: () => {
       notifications.show({

--- a/ui/src/hooks/useSubmitHeadToHeadVote.ts
+++ b/ui/src/hooks/useSubmitHeadToHeadVote.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
 
 function getSubmitHeadToHeadVoteQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/head-to-head/vote', 'POST'];
+  return [getProjectApiUrl(projectSlug), '/head-to-head/vote', 'POST'];
 }
 
 type HeadToHeadVoteRequest = {
@@ -21,7 +21,7 @@ export function useSubmitHeadToHeadVote({ projectSlug, options }: Params) {
   return useMutation({
     mutationKey: getSubmitHeadToHeadVoteQueryKey(projectSlug),
     mutationFn: async (request: HeadToHeadVoteRequest) => {
-      const response = await fetch(`${getProjectUrl(projectSlug)}/head-to-head/vote`, {
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/head-to-head/vote`, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useSubmitHeadToHeadVote.ts
+++ b/ui/src/hooks/useSubmitHeadToHeadVote.ts
@@ -1,10 +1,6 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
-
-function getSubmitHeadToHeadVoteQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/head-to-head/vote', 'POST'];
-}
 
 type HeadToHeadVoteRequest = {
   response_a_id: number;
@@ -18,14 +14,18 @@ type Params = {
 };
 export function useSubmitHeadToHeadVote({ projectSlug, options }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.submitHeadToHeadVote(projectSlug);
   return useMutation({
-    mutationKey: getSubmitHeadToHeadVoteQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: HeadToHeadVoteRequest) => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/head-to-head/vote`, {
+      const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },
       });
+      if (!response.ok) {
+        throw new Error('Failed to submit vote');
+      }
       await response.json();
     },
     onSettled: () => {

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -1,11 +1,7 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { Task } from './useTasks.ts';
-
-function getTaskStreamQueryKey(projectSlug: string, task: Task) {
-  return [getProjectApiUrl(projectSlug), '/task', task.id, '/stream'];
-}
 
 type Params = {
   projectSlug: string;
@@ -14,13 +10,14 @@ type Params = {
 };
 export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQueryResult<Task, Error> {
   const queryClient = useQueryClient();
-  const queryKey = getTaskStreamQueryKey(projectSlug, task);
+  const url = API_ROUTES.getTaskStream(projectSlug, task.id);
+  const queryKey = urlAsQueryKey(url);
 
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       let latest = task;
-      await fetchEventSource(`${getProjectApiUrl(projectSlug)}/task/${task.id}/stream`, {
+      await fetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -1,10 +1,10 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { Task } from './useTasks.ts';
 
 function getTaskStreamQueryKey(projectSlug: string, task: Task) {
-  return [getProjectUrl(projectSlug), '/task', task.id, '/stream'];
+  return [getProjectApiUrl(projectSlug), '/task', task.id, '/stream'];
 }
 
 type Params = {
@@ -20,7 +20,7 @@ export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQ
     queryKey,
     queryFn: async ({ signal }) => {
       let latest = task;
-      await fetchEventSource(`${getProjectUrl(projectSlug)}/task/${task.id}/stream`, {
+      await fetchEventSource(`${getProjectApiUrl(projectSlug)}/task/${task.id}/stream`, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useTasks.ts
+++ b/ui/src/hooks/useTasks.ts
@@ -1,8 +1,8 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 
 export function getTasksQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/tasks'];
+  return [getProjectApiUrl(projectSlug), '/tasks'];
 }
 
 export type Task = {
@@ -22,7 +22,7 @@ export function useTasks({ projectSlug, options = {} }: Params) {
   return useQuery({
     queryKey: getTasksQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const url = `${getProjectUrl(projectSlug ?? '')}/tasks`;
+      const url = `${getProjectApiUrl(projectSlug ?? '')}/tasks`;
       const response = await fetch(url);
       if (!response.ok) {
         return [];

--- a/ui/src/hooks/useTasks.ts
+++ b/ui/src/hooks/useTasks.ts
@@ -1,8 +1,8 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 
 export function getTasksQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/tasks'];
+  return urlAsQueryKey(API_ROUTES.getTasks(projectSlug));
 }
 
 export type Task = {
@@ -19,13 +19,13 @@ type Params = {
   options?: Partial<UseQueryOptions<Task[]>>;
 };
 export function useTasks({ projectSlug, options = {} }: Params) {
+  const url = API_ROUTES.getTasks(projectSlug ?? '');
   return useQuery({
     queryKey: getTasksQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const url = `${getProjectApiUrl(projectSlug ?? '')}/tasks`;
       const response = await fetch(url);
       if (!response.ok) {
-        return [];
+        throw new Error('Failed to fetch tasks');
       }
       const result: Task[] = await response.json();
       return result;

--- a/ui/src/hooks/useTriggerAutoJudge.ts
+++ b/ui/src/hooks/useTriggerAutoJudge.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
 
 function getTriggerAutoJudgeQueryKey(projectSlug: string) {
-  return [getProjectUrl(projectSlug), '/judge'];
+  return [getProjectApiUrl(projectSlug), '/judge'];
 }
 
 type TriggerAutoJudgeRequest = {
@@ -21,7 +21,7 @@ export function useTriggerAutoJudge({ projectSlug, options = {} }: Params) {
   return useMutation({
     mutationKey: getTriggerAutoJudgeQueryKey(projectSlug),
     mutationFn: async (request: TriggerAutoJudgeRequest) => {
-      const response = await fetch(`${getProjectUrl(projectSlug)}/task/auto-judge`, {
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/task/auto-judge`, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useTriggerAutoJudge.ts
+++ b/ui/src/hooks/useTriggerAutoJudge.ts
@@ -1,11 +1,7 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
-
-function getTriggerAutoJudgeQueryKey(projectSlug: string) {
-  return [getProjectApiUrl(projectSlug), '/judge'];
-}
 
 type TriggerAutoJudgeRequest = {
   judge_ids: number[];
@@ -18,10 +14,11 @@ type Params = {
   options?: UseMutationOptions<void, Error, TriggerAutoJudgeRequest>;
 };
 export function useTriggerAutoJudge({ projectSlug, options = {} }: Params) {
+  const url = API_ROUTES.triggerAutoJudge(projectSlug);
   return useMutation({
-    mutationKey: getTriggerAutoJudgeQueryKey(projectSlug),
+    mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: TriggerAutoJudgeRequest) => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/task/auto-judge`, {
+      const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useTriggerModelAutoJudge.ts
+++ b/ui/src/hooks/useTriggerModelAutoJudge.ts
@@ -1,11 +1,7 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
-
-function getTriggerModelJudgementQueryKey(projectSlug: string, modelId: number | undefined) {
-  return [getProjectApiUrl(projectSlug), '/model', modelId, '/judge'];
-}
 
 type Params = {
   projectSlug: string;
@@ -13,10 +9,14 @@ type Params = {
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useTriggerModelAutoJudge({ projectSlug, modelId, options = {} }: Params) {
+  const url = API_ROUTES.triggerModelAutoJudge(projectSlug, modelId ?? -1);
   return useMutation({
-    mutationKey: getTriggerModelJudgementQueryKey(projectSlug, modelId),
+    mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async () => {
-      await fetch(`${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`, { method: 'POST' });
+      const response = await fetch(url, { method: 'POST' });
+      if (!response.ok) {
+        throw new Error('Failed to start automated judgement for model');
+      }
     },
     onSuccess: () => {
       notifications.show({

--- a/ui/src/hooks/useTriggerModelAutoJudge.ts
+++ b/ui/src/hooks/useTriggerModelAutoJudge.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
 
 function getTriggerModelJudgementQueryKey(projectSlug: string, modelId: number | undefined) {
-  return [getProjectUrl(projectSlug), '/model', modelId, '/judge'];
+  return [getProjectApiUrl(projectSlug), '/model', modelId, '/judge'];
 }
 
 type Params = {
@@ -16,7 +16,7 @@ export function useTriggerModelAutoJudge({ projectSlug, modelId, options = {} }:
   return useMutation({
     mutationKey: getTriggerModelJudgementQueryKey(projectSlug, modelId),
     mutationFn: async () => {
-      await fetch(`${getProjectUrl(projectSlug)}/model/${modelId}/judge`, { method: 'POST' });
+      await fetch(`${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`, { method: 'POST' });
     },
     onSuccess: () => {
       notifications.show({

--- a/ui/src/hooks/useUpdateJudge.ts
+++ b/ui/src/hooks/useUpdateJudge.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
 
 function getUpdateJudgeQueryKey(projectSlug: string, judgeId: number) {
-  return [getProjectUrl(projectSlug), '/judge', judgeId];
+  return [getProjectApiUrl(projectSlug), '/judge', judgeId];
 }
 
 type UpdateJudgeRequest = {
@@ -20,7 +20,7 @@ export function useUpdateJudge({ projectSlug, judgeId, options = {} }: Params) {
   return useMutation({
     mutationKey: getUpdateJudgeQueryKey(projectSlug, judgeId),
     mutationFn: async (request: UpdateJudgeRequest) => {
-      const response = await fetch(`${getProjectUrl(projectSlug)}/judge/${judgeId}`, {
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge/${judgeId}`, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useUpdateJudge.ts
+++ b/ui/src/hooks/useUpdateJudge.ts
@@ -1,10 +1,6 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
-import { getProjectApiUrl } from '../lib/routes.ts';
+import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
-
-function getUpdateJudgeQueryKey(projectSlug: string, judgeId: number) {
-  return [getProjectApiUrl(projectSlug), '/judge', judgeId];
-}
 
 type UpdateJudgeRequest = {
   enabled: boolean;
@@ -17,14 +13,18 @@ type Params = {
 };
 export function useUpdateJudge({ projectSlug, judgeId, options = {} }: Params) {
   const queryClient = useQueryClient();
+  const url = API_ROUTES.updateJudge(projectSlug, judgeId);
   return useMutation({
-    mutationKey: getUpdateJudgeQueryKey(projectSlug, judgeId),
+    mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async (request: UpdateJudgeRequest) => {
-      const response = await fetch(`${getProjectApiUrl(projectSlug)}/judge/${judgeId}`, {
+      const response = await fetch(url, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },
       });
+      if (!response.ok) {
+        throw new Error('Failed to update judge');
+      }
       const result: Judge = await response.json();
       return result;
     },

--- a/ui/src/hooks/useUploadModelResponses.ts
+++ b/ui/src/hooks/useUploadModelResponses.ts
@@ -1,12 +1,12 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { zip } from 'ramda';
-import { getProjectUrl } from '../lib/routes.ts';
+import { getProjectApiUrl } from '../lib/routes.ts';
 import { getModelsQueryKey, Model } from './useModels.ts';
 import { getTasksQueryKey } from './useTasks.ts';
 
 function getUploadModelResponsesQueryKey(projectSlug: string) {
-  return [`${getProjectUrl(projectSlug)}`, '/model', 'POST'];
+  return [`${getProjectApiUrl(projectSlug)}`, '/model', 'POST'];
 }
 
 type Params = {
@@ -26,7 +26,7 @@ export function useUploadModelResponses({ projectSlug, options }: Params) {
         formData.append(file.name, file);
         formData.append(`${file.name}||model_name`, modelName); // format here is enforced by backend
       });
-      const response = await fetch(`${getProjectUrl(projectSlug)}/model`, { method: 'POST', body: formData });
+      const response = await fetch(`${getProjectApiUrl(projectSlug)}/model`, { method: 'POST', body: formData });
       const result: Model[] = await response.json();
       return result;
     },

--- a/ui/src/hooks/useUrlState.ts
+++ b/ui/src/hooks/useUrlState.ts
@@ -1,4 +1,5 @@
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { ROUTES } from '../lib/routes.ts';
 
 export function useUrlState() {
   const { projectSlug: projectSlugFromUrl } = useParams();
@@ -7,7 +8,7 @@ export function useUrlState() {
 
   const projectSlug = typeof projectSlugFromUrl === 'string' ? projectSlugFromUrl : undefined;
   function setProjectSlug(newProjectSlug: string | null | undefined) {
-    navigate(newProjectSlug != null ? `/project/${newProjectSlug}` : '/');
+    navigate(newProjectSlug != null ? ROUTES.leaderboard(newProjectSlug) : ROUTES.home());
   }
 
   const judgeIdFromUrl = searchParams.get('judgeId');

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,5 @@
+export const AUTH0 = {
+  DOMAIN: import.meta.env.VITE_AUTH0_DOMAIN ?? '',
+  CLIENT_ID: import.meta.env.VITE_AUTH0_CLIENT_ID ?? '',
+  API_AUDIENCE: import.meta.env.VITE_AUTH0_API_AUDIENCE ?? '',
+};

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -28,3 +28,40 @@ export const ROUTES = {
   compare: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/compare`,
   judges: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/judges`,
 };
+
+export const API_ROUTES = {
+  getProjects: () => `${getBaseApiUrl()}/projects`,
+  createProject: () => `${getBaseApiUrl()}/project`,
+  deleteProject: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}`,
+  getModels: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/models`,
+  getModelsRankedByJudge: (projectSlug: string, judgeId: number) =>
+    `${getProjectApiUrl(projectSlug)}/models/by-judge/${judgeId}`,
+  uploadModelResponses: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/model`,
+  getModelResponse: (projectSlug: string, modelId: number) => `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
+  triggerModelAutoJudge: (projectSlug: string, modelId: number) =>
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
+  deleteModel: (projectSlug: string, modelId: number) => `${getProjectApiUrl(projectSlug)}/model/${modelId}`,
+  downloadModelResponsesCsv: (projectSlug: string, modelId: number) =>
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/download/responses`,
+  downloadModelHeadToHeadsCsv: (projectSlug: string, modelId: number) =>
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/download/head-to-heads`,
+  getHeadToHeadStats: (projectSlug: string, modelId: number) =>
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/head-to-head/stats`,
+  getHeadToHeads: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/head-to-heads`,
+  getHeadToHeadCount: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/head-to-head/count`,
+  submitHeadToHeadVote: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/head-to-head/vote`,
+  getTasks: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/tasks`,
+  getTaskStream: (projectSlug: string, taskId: number) => `${getProjectApiUrl(projectSlug)}/task/${taskId}/stream`,
+  getHasActiveTasksStream: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/tasks/has-active`,
+  deleteCompletedTasks: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/tasks/completed`,
+  triggerAutoJudge: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/task/auto-judge`,
+  getJudges: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/judges`,
+  getDefaultSystemPrompt: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/judge/default-system-prompt`,
+  createJudge: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/judge`,
+  updateJudge: (projectSlug: string, judgeId: number) => `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`,
+  checkCanAccess: (projectSlug: string, judgeType: string) =>
+    `${getProjectApiUrl(projectSlug)}/judge/${judgeType}/can-access`, // TODO: use enum type?
+  deleteJudge: (projectSlug: string, judgeId: number) => `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`,
+  reseedEloScores: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/elo/reseed-scores`,
+  createFineTuningTask: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/fine-tune`,
+};

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -19,11 +19,11 @@ export function getProjectApiUrl(projectSlug: string) {
 
 function getBasePath() {
   const { isLocalMode } = getAppMode();
-  return isLocalMode ? '/' : `/${getTenantName()}`;
+  return isLocalMode ? '' : `/${getTenantName()}`;
 }
 
 export const ROUTES = {
-  home: () => getBasePath(),
+  home: () => `${getBasePath()}/`,
   leaderboard: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}`,
   compare: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/compare`,
   judges: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/judges`,

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -1,5 +1,5 @@
-// TODO: collect various API URLs in this file
 import { getAppMode } from '../hooks/useAppMode';
+import { JudgeType } from '../components/Judges/types.ts';
 
 const LOCAL_BASE_API_URL = 'http://localhost:8899/api/v1';
 
@@ -8,7 +8,7 @@ function getTenantName() {
   return pathParts.length > 0 ? pathParts[0] : undefined;
 }
 
-export function getBaseApiUrl() {
+function getBaseApiUrl() {
   const { isLocalMode } = getAppMode();
   return isLocalMode ? LOCAL_BASE_API_URL : `${window.location.origin}/api/v1/${getTenantName()}`;
 }
@@ -37,7 +37,8 @@ export const API_ROUTES = {
   getModelsRankedByJudge: (projectSlug: string, judgeId: number) =>
     `${getProjectApiUrl(projectSlug)}/models/by-judge/${judgeId}`,
   uploadModelResponses: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/model`,
-  getModelResponse: (projectSlug: string, modelId: number) => `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
+  getModelResponses: (projectSlug: string, modelId: number) =>
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
   triggerModelAutoJudge: (projectSlug: string, modelId: number) =>
     `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
   deleteModel: (projectSlug: string, modelId: number) => `${getProjectApiUrl(projectSlug)}/model/${modelId}`,
@@ -59,9 +60,15 @@ export const API_ROUTES = {
   getDefaultSystemPrompt: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/judge/default-system-prompt`,
   createJudge: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/judge`,
   updateJudge: (projectSlug: string, judgeId: number) => `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`,
-  checkCanAccess: (projectSlug: string, judgeType: string) =>
-    `${getProjectApiUrl(projectSlug)}/judge/${judgeType}/can-access`, // TODO: use enum type?
+  checkCanAccess: (projectSlug: string, judgeType: JudgeType) =>
+    `${getProjectApiUrl(projectSlug)}/judge/${judgeType}/can-access`,
   deleteJudge: (projectSlug: string, judgeId: number) => `${getProjectApiUrl(projectSlug)}/judge/${judgeId}`,
   reseedEloScores: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/elo/reseed-scores`,
   createFineTuningTask: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/fine-tune`,
 };
+
+type HTTPVerb = 'GET' | 'PUT' | 'POST' | 'DELETE';
+export function urlAsQueryKey(url: string, method: HTTPVerb = 'GET') {
+  const urlObject = new URL(url);
+  return [urlObject.origin, ...urlObject.pathname.split('/').filter(Boolean), method];
+}

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -3,16 +3,28 @@ import { getAppMode } from '../hooks/useAppMode';
 
 const LOCAL_BASE_API_URL = 'http://localhost:8899/api/v1';
 
-export function getBaseUrl() {
-  const { isLocalMode } = getAppMode();
-  if (isLocalMode) {
-    return LOCAL_BASE_API_URL;
-  }
+function getTenantName() {
   const pathParts = new URL(window.location.href).pathname.split('/').filter(Boolean);
-  const tenant = pathParts.length > 0 ? pathParts[0] : '';
-  return `${window.location.origin}/api/v1/${tenant}`;
+  return pathParts.length > 0 ? pathParts[0] : undefined;
 }
 
-export function getProjectUrl(projectSlug: string) {
-  return `${getBaseUrl()}/project/${projectSlug}`;
+export function getBaseApiUrl() {
+  const { isLocalMode } = getAppMode();
+  return isLocalMode ? LOCAL_BASE_API_URL : `${window.location.origin}/api/v1/${getTenantName()}`;
 }
+
+export function getProjectApiUrl(projectSlug: string) {
+  return `${getBaseApiUrl()}/project/${projectSlug}`;
+}
+
+function getBasePath() {
+  const { isLocalMode } = getAppMode();
+  return isLocalMode ? '/' : `/${getTenantName()}`;
+}
+
+export const ROUTES = {
+  home: () => getBasePath(),
+  leaderboard: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}`,
+  compare: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/compare`,
+  judges: (projectSlug: string) => `${getBasePath()}/project/${projectSlug}/judges`,
+};

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -38,7 +38,7 @@ export const API_ROUTES = {
     `${getProjectApiUrl(projectSlug)}/models/by-judge/${judgeId}`,
   uploadModelResponses: (projectSlug: string) => `${getProjectApiUrl(projectSlug)}/model`,
   getModelResponses: (projectSlug: string, modelId: number) =>
-    `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
+    `${getProjectApiUrl(projectSlug)}/model/${modelId}/responses`,
   triggerModelAutoJudge: (projectSlug: string, modelId: number) =>
     `${getProjectApiUrl(projectSlug)}/model/${modelId}/judge`,
   deleteModel: (projectSlug: string, modelId: number) => `${getProjectApiUrl(projectSlug)}/model/${modelId}`,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10,6 +10,18 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@auth0/auth0-react@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-react/-/auth0-react-2.2.4.tgz#7f21751a219d4e0e019141819f00e76e436176dd"
+  integrity sha512-l29PQC0WdgkCoOc6WeMAY26gsy/yXJICW0jHfj0nz8rZZphYKrLNqTRWFFCMJY+sagza9tSgB1kG/UvQYgGh9A==
+  dependencies:
+    "@auth0/auth0-spa-js" "^2.1.3"
+
+"@auth0/auth0-spa-js@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz#aabf6f439e41edbeef0cf4766ad754e5b47616e5"
+  integrity sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
@@ -865,85 +877,85 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.19.1.tgz#984771bfd1de2715f42394c87fb716c1349e014f"
   integrity sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==
 
-"@rollup/rollup-android-arm-eabi@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.1.tgz#c3a7938551273a2b72820cf5d22e54cf41dc206e"
-  integrity sha512-2thheikVEuU7ZxFXubPDOtspKn1x0yqaYQwvALVtEcvFhMifPADBrgRPyHV0TF3b+9BgvgjgagVyvA/UqPZHmg==
+"@rollup/rollup-android-arm-eabi@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz#155c7d82c1b36c3ad84d9adf9b3cd520cba81a0f"
+  integrity sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==
 
-"@rollup/rollup-android-arm64@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.1.tgz#fa3693e4674027702c42fcbbb86bbd0c635fd3b9"
-  integrity sha512-t1lLYn4V9WgnIFHXy1d2Di/7gyzBWS8G5pQSXdZqfrdCGTwi1VasRMSS81DTYb+avDs/Zz4A6dzERki5oRYz1g==
+"@rollup/rollup-android-arm64@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz#b94b6fa002bd94a9cbd8f9e47e23b25e5bd113ba"
+  integrity sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==
 
-"@rollup/rollup-darwin-arm64@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.1.tgz#e19922f4ac1e4552a230ff8f49d5688c5c07d284"
-  integrity sha512-AH/wNWSEEHvs6t4iJ3RANxW5ZCK3fUnmf0gyMxWCesY1AlUj8jY7GC+rQE4wd3gwmZ9XDOpL0kcFnCjtN7FXlA==
+"@rollup/rollup-darwin-arm64@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz#0934126cf9cbeadfe0eb7471ab5d1517e8cd8dcc"
+  integrity sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==
 
-"@rollup/rollup-darwin-x64@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.1.tgz#897f8d47b115ea84692a29cf2366899499d4d915"
-  integrity sha512-dO0BIz/+5ZdkLZrVgQrDdW7m2RkrLwYTh2YMFG9IpBtlC1x1NPNSXkfczhZieOlOLEqgXOFH3wYHB7PmBtf+Bg==
+"@rollup/rollup-darwin-x64@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz#0ce8e1e0f349778938c7c90e4bdc730640e0a13e"
+  integrity sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.1.tgz#7d1e2a542f3a5744f5c24320067bd5af99ec9d62"
-  integrity sha512-sWWgdQ1fq+XKrlda8PsMCfut8caFwZBmhYeoehJ05FdI0YZXk6ZyUjWLrIgbR/VgiGycrFKMMgp7eJ69HOF2pQ==
+"@rollup/rollup-linux-arm-gnueabihf@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz#5669d34775ad5d71e4f29ade99d0ff4df523afb6"
+  integrity sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==
 
-"@rollup/rollup-linux-arm-musleabihf@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.1.tgz#88bec1c9df85fc5e24d49f783e19934717dd69b5"
-  integrity sha512-9OIiSuj5EsYQlmwhmFRA0LRO0dRRjdCVZA3hnmZe1rEwRk11Jy3ECGGq3a7RrVEZ0/pCsYWx8jG3IvcrJ6RCew==
+"@rollup/rollup-linux-arm-musleabihf@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz#f6d1a0e1da4061370cb2f4244fbdd727c806dd88"
+  integrity sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==
 
-"@rollup/rollup-linux-arm64-gnu@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.1.tgz#6dc60f0fe7bd49ed07a2d4d9eab15e671b3bd59d"
-  integrity sha512-0kuAkRK4MeIUbzQYu63NrJmfoUVicajoRAL1bpwdYIYRcs57iyIV9NLcuyDyDXE2GiZCL4uhKSYAnyWpjZkWow==
+"@rollup/rollup-linux-arm64-gnu@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz#ed96a05e99743dee4d23cc4913fc6e01a0089c88"
+  integrity sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==
 
-"@rollup/rollup-linux-arm64-musl@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.1.tgz#a03b78775c129e8333aca9e1e420e8e217ee99b9"
-  integrity sha512-/6dYC9fZtfEY0vozpc5bx1RP4VrtEOhNQGb0HwvYNwXD1BBbwQ5cKIbUVVU7G2d5WRE90NfB922elN8ASXAJEA==
+"@rollup/rollup-linux-arm64-musl@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz#057ea26eaa7e537a06ded617d23d57eab3cecb58"
+  integrity sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.1.tgz#ee3810647faf2c105a5a4e71260bb90b96bf87bc"
-  integrity sha512-ltUWy+sHeAh3YZ91NUsV4Xg3uBXAlscQe8ZOXRCVAKLsivGuJsrkawYPUEyCV3DYa9urgJugMLn8Z3Z/6CeyRQ==
+"@rollup/rollup-linux-powerpc64le-gnu@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz#6e6e1f9404c9bf3fbd7d51cd11cd288a9a2843aa"
+  integrity sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==
 
-"@rollup/rollup-linux-riscv64-gnu@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.1.tgz#385d76a088c27db8054d9f3f28d64d89294f838e"
-  integrity sha512-BggMndzI7Tlv4/abrgLwa/dxNEMn2gC61DCLrTzw8LkpSKel4o+O+gtjbnkevZ18SKkeN3ihRGPuBxjaetWzWg==
+"@rollup/rollup-linux-riscv64-gnu@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz#eef1536a53f6e6658a2a778130e6b1a4a41cb439"
+  integrity sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==
 
-"@rollup/rollup-linux-s390x-gnu@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.1.tgz#daa2b62a6e6f737ebef6700a12a93c9764e18583"
-  integrity sha512-z/9rtlGd/OMv+gb1mNSjElasMf9yXusAxnRDrBaYB+eS1shFm6/4/xDH1SAISO5729fFKUkJ88TkGPRUh8WSAA==
+"@rollup/rollup-linux-s390x-gnu@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz#2b28fb89ca084efaf8086f435025d96b4a966957"
+  integrity sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==
 
-"@rollup/rollup-linux-x64-gnu@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.1.tgz#790ae96118cc892464e9f10da358c0c8a6b9acdd"
-  integrity sha512-kXQVcWqDcDKw0S2E0TmhlTLlUgAmMVqPrJZR+KpH/1ZaZhLSl23GZpQVmawBQGVhyP5WXIsIQ/zqbDBBYmxm5w==
+"@rollup/rollup-linux-x64-gnu@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz#5226cde6c6b495b04a3392c1d2c572844e42f06b"
+  integrity sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==
 
-"@rollup/rollup-linux-x64-musl@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.1.tgz#d613147f7ac15fafe2a0b6249e8484e161ca2847"
-  integrity sha512-CbFv/WMQsSdl+bpX6rVbzR4kAjSSBuDgCqb1l4J68UYsQNalz5wOqLGYj4ZI0thGpyX5kc+LLZ9CL+kpqDovZA==
+"@rollup/rollup-linux-x64-musl@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz#2c2412982e6c2a00a2ecac6d548ebb02f0aa6ca4"
+  integrity sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==
 
-"@rollup/rollup-win32-arm64-msvc@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.1.tgz#18349db8250559a5460d59eb3575f9781be4ab98"
-  integrity sha512-3Q3brDgA86gHXWHklrwdREKIrIbxC0ZgU8lwpj0eEKGBQH+31uPqr0P2v11pn0tSIxHvcdOWxa4j+YvLNx1i6g==
+"@rollup/rollup-win32-arm64-msvc@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz#fbb6ef5379199e2ec0103ef32877b0985c773a55"
+  integrity sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==
 
-"@rollup/rollup-win32-ia32-msvc@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.1.tgz#199648b68271f7ab9d023f5c077725d51d12d466"
-  integrity sha512-tNg+jJcKR3Uwe4L0/wY3Ro0H+u3nrb04+tcq1GSYzBEmKLeOQF2emk1whxlzNqb6MMrQ2JOcQEpuuiPLyRcSIw==
+"@rollup/rollup-win32-ia32-msvc@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz#d50e2082e147e24d87fe34abbf6246525ec3845a"
+  integrity sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==
 
-"@rollup/rollup-win32-x64-msvc@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.1.tgz#4d3ec02dbf280c20bfeac7e50cd5669b66f9108f"
-  integrity sha512-xGiIH95H1zU7naUyTKEyOA/I0aexNMUdO9qRv0bLKN3qu25bBdrxZHqA3PTJ24YNN/GdMzG4xkDcd/GvjuhfLg==
+"@rollup/rollup-win32-x64-msvc@4.21.3":
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz#4115233aa1bd5a2060214f96d8511f6247093212"
+  integrity sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -4941,12 +4953,12 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picocolors@^1.0.0, picocolors@^1.0.1:
+picocolors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
-picocolors@^1.1.0:
+picocolors@^1.0.1, picocolors@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
   integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
@@ -5001,16 +5013,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.41:
-  version "8.4.41"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.41.tgz#d6104d3ba272d882fe18fc07d15dc2da62fa2681"
-  integrity sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.1"
-    source-map-js "^1.2.0"
-
-postcss@^8.4.43:
+postcss@^8.4.41, postcss@^8.4.43:
   version "8.4.47"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.47.tgz#5bf6c9a010f3e724c503bf03ef7947dcb0fea365"
   integrity sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==
@@ -5387,28 +5390,28 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^4.20.0:
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.21.1.tgz#65b9b9e9de9a64604fab083fb127f3e9eac2935d"
-  integrity sha512-ZnYyKvscThhgd3M5+Qt3pmhO4jIRR5RGzaSovB6Q7rGNrK5cUncrtLmcTTJVSdcKXyZjW8X8MB0JMSuH9bcAJg==
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.21.3.tgz#c64ba119e6aeb913798a6f7eef2780a0df5a0821"
+  integrity sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==
   dependencies:
     "@types/estree" "1.0.5"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.21.1"
-    "@rollup/rollup-android-arm64" "4.21.1"
-    "@rollup/rollup-darwin-arm64" "4.21.1"
-    "@rollup/rollup-darwin-x64" "4.21.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.21.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.21.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.21.1"
-    "@rollup/rollup-linux-arm64-musl" "4.21.1"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.21.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.21.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.21.1"
-    "@rollup/rollup-linux-x64-gnu" "4.21.1"
-    "@rollup/rollup-linux-x64-musl" "4.21.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.21.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.21.1"
-    "@rollup/rollup-win32-x64-msvc" "4.21.1"
+    "@rollup/rollup-android-arm-eabi" "4.21.3"
+    "@rollup/rollup-android-arm64" "4.21.3"
+    "@rollup/rollup-darwin-arm64" "4.21.3"
+    "@rollup/rollup-darwin-x64" "4.21.3"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.21.3"
+    "@rollup/rollup-linux-arm-musleabihf" "4.21.3"
+    "@rollup/rollup-linux-arm64-gnu" "4.21.3"
+    "@rollup/rollup-linux-arm64-musl" "4.21.3"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.21.3"
+    "@rollup/rollup-linux-riscv64-gnu" "4.21.3"
+    "@rollup/rollup-linux-s390x-gnu" "4.21.3"
+    "@rollup/rollup-linux-x64-gnu" "4.21.3"
+    "@rollup/rollup-linux-x64-musl" "4.21.3"
+    "@rollup/rollup-win32-arm64-msvc" "4.21.3"
+    "@rollup/rollup-win32-ia32-msvc" "4.21.3"
+    "@rollup/rollup-win32-x64-msvc" "4.21.3"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
@@ -5555,7 +5558,7 @@ slice-ansi@^7.1.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
-source-map-js@^1.0.1, source-map-js@^1.2.0:
+source-map-js@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==


### PR DESCRIPTION
Collect all internal and API routes into `routes.ts` and reference from there. This is a saner way to organize the app than having them scattered all over the place, even if it makes for a relatively large diff.