### PR TITLE
Add bearer token to API fetches in cloud mode

### DIFF
--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -7,7 +7,6 @@ import {
   IconHome,
   IconLogout,
   IconStack2Filled,
-  IconUser,
 } from '@tabler/icons-react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useAppMode } from '../hooks/useAppMode.ts';
@@ -49,7 +48,6 @@ export function MainMenu() {
         {isCloudMode && (
           <>
             <Menu.Divider />
-            {user != null && <Menu.Item leftSection={<IconUser {...iconProps} />}>{user.email}</Menu.Item>}
             <Menu.Item
               leftSection={<IconLogout {...iconProps} />}
               onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}

--- a/ui/src/hooks/useApiFetch.ts
+++ b/ui/src/hooks/useApiFetch.ts
@@ -1,0 +1,26 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { AUTH0 } from '../lib/auth.ts';
+import { useAppMode } from './useAppMode.ts';
+
+export function useApiFetch() {
+  const { isLocalMode } = useAppMode();
+  const { getAccessTokenSilently, logout } = useAuth0();
+
+  async function apiFetch(input: RequestInfo | URL, init?: RequestInit | undefined) {
+    const token = await getAccessTokenSilently({ authorizationParams: { audience: AUTH0.API_AUDIENCE } });
+    const response = await fetch(input, {
+      ...init,
+      headers: {
+        ...init?.headers,
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (response.status === 401) {
+      await logout({ logoutParams: { returnTo: window.location.origin } });
+    }
+
+    return response;
+  }
+
+  return { apiFetch: isLocalMode ? fetch : apiFetch };
+}

--- a/ui/src/hooks/useCanAccessJudgeType.ts
+++ b/ui/src/hooks/useCanAccessJudgeType.ts
@@ -1,17 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { JudgeType } from '../components/Judges/types.ts';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
   judgeType?: JudgeType;
 };
 export function useCanAccessJudgeType({ projectSlug, judgeType }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.checkCanAccess(projectSlug, judgeType ?? 'unrecognized');
   return useQuery({
     queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to check judge type availability');
       }

--- a/ui/src/hooks/useClearCompletedTasks.ts
+++ b/ui/src/hooks/useClearCompletedTasks.ts
@@ -1,18 +1,20 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug?: string;
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useClearCompletedTasks({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.deleteCompletedTasks(projectSlug ?? '');
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'DELETE' });
+      const response = await apiFetch(url, { method: 'DELETE' });
       if (!response.ok) {
         throw new Error('Failed to clear completed tasks');
       }

--- a/ui/src/hooks/useCreateFineTuningTask.ts
+++ b/ui/src/hooks/useCreateFineTuningTask.ts
@@ -2,6 +2,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
+import {useApiFetch} from "./useApiFetch.ts";
 
 type CreateFineTuningTaskRequest = {
   base_model: string;
@@ -13,12 +14,13 @@ type Params = {
   options?: UseMutationOptions<void, Error, CreateFineTuningTaskRequest>;
 };
 export function useCreateFineTuningTask({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.createFineTuningTask(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: CreateFineTuningTaskRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useCreateFineTuningTask.ts
+++ b/ui/src/hooks/useCreateFineTuningTask.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getTasksQueryKey } from './useTasks.ts';
-import {useApiFetch} from "./useApiFetch.ts";
+import { useApiFetch } from './useApiFetch.ts';
 
 type CreateFineTuningTaskRequest = {
   base_model: string;

--- a/ui/src/hooks/useCreateJudge.ts
+++ b/ui/src/hooks/useCreateJudge.ts
@@ -3,6 +3,7 @@ import { notifications } from '@mantine/notifications';
 import { JudgeType } from '../components/Judges/types.ts';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type CreateJudgeRequest = {
   judge_type: JudgeType;
@@ -17,12 +18,13 @@ type Params = {
   options?: UseMutationOptions<Judge, Error, CreateJudgeRequest>;
 };
 export function useCreateJudge({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.createJudge(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: CreateJudgeRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useCreateProject.ts
+++ b/ui/src/hooks/useCreateProject.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getProjectsQueryKey, Project } from './useProjects.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type CreateProjectRequest = {
   name: string;
@@ -11,13 +12,14 @@ type CreateProjectRequest = {
 export function useCreateProject({
   options,
 }: { options?: UseMutationOptions<Project, Error, CreateProjectRequest> } = {}) {
+  const { apiFetch } = useApiFetch();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const url = API_ROUTES.createProject();
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async (request: CreateProjectRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useDeleteJudge.ts
+++ b/ui/src/hooks/useDeleteJudge.ts
@@ -3,6 +3,7 @@ import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey } from './useJudges.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
@@ -10,12 +11,13 @@ type Params = {
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteJudge({ projectSlug, judgeId, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.deleteJudge(projectSlug, judgeId);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'DELETE' });
+      const response = await apiFetch(url, { method: 'DELETE' });
       if (!response.ok) {
         throw new Error('Failed to delete judge');
       }

--- a/ui/src/hooks/useDeleteModel.ts
+++ b/ui/src/hooks/useDeleteModel.ts
@@ -3,6 +3,7 @@ import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
 import { getModelHeadToHeadStatsQueryKey } from './useModelHeadToHeadStats.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
@@ -10,12 +11,13 @@ type Params = {
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteModel({ projectSlug, modelId, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.deleteModel(projectSlug, modelId);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'DELETE' });
+      const response = await apiFetch(url, { method: 'DELETE' });
       if (!response.ok) {
         throw new Error('Failed to delete model');
       }

--- a/ui/src/hooks/useDeleteProject.ts
+++ b/ui/src/hooks/useDeleteProject.ts
@@ -2,18 +2,20 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getProjectsQueryKey } from './useProjects.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useDeleteProject({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.deleteProject(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'DELETE'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'DELETE' });
+      const response = await apiFetch(url, { method: 'DELETE' });
       if (!response.ok) {
         throw new Error('Failed to delete project');
       }

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -7,6 +7,7 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
   const url = API_ROUTES.getHasActiveTasksStream(projectSlug ?? '');
   const queryKey = urlAsQueryKey(url);
 
+  // TODO: auth header
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -1,8 +1,9 @@
-import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<boolean, Error> {
+  const { apiFetchEventSource } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.getHasActiveTasksStream(projectSlug ?? '');
   const queryKey = urlAsQueryKey(url);
@@ -11,7 +12,7 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
-      await fetchEventSource(url, {
+      await apiFetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useHeadToHeadCount.ts
+++ b/ui/src/hooks/useHeadToHeadCount.ts
@@ -1,12 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function useHeadToHeadCount(projectSlug?: string) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getHeadToHeadCount(projectSlug ?? '');
   return useQuery({
     queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch head-to-head count');
       }

--- a/ui/src/hooks/useHeadToHeads.ts
+++ b/ui/src/hooks/useHeadToHeads.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export type HeadToHeadHistoryItem = {
   judge_id: number;
@@ -22,12 +23,13 @@ type Params = {
   modelBId: number;
 };
 export function useHeadToHeads({ projectSlug, modelAId, modelBId }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getHeadToHeads(projectSlug);
   return useQuery({
     queryKey: [...urlAsQueryKey(url), modelAId, modelBId],
     queryFn: async () => {
       const body = { model_a_id: modelAId, model_b_id: modelBId };
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'PUT',
         body: JSON.stringify(body),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
+++ b/ui/src/hooks/useJudgeDefaultSystemPrompt.ts
@@ -1,12 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function useJudgeDefaultSystemPrompt(projectSlug: string) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getDefaultSystemPrompt(projectSlug);
   return useQuery({
     queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch default judge system prompt');
       }

--- a/ui/src/hooks/useJudges.ts
+++ b/ui/src/hooks/useJudges.ts
@@ -1,6 +1,7 @@
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { JudgeType } from '../components/Judges/types.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function getJudgesQueryKey(projectSlug: string) {
   return urlAsQueryKey(API_ROUTES.getJudges(projectSlug));
@@ -19,11 +20,12 @@ export type Judge = {
 };
 
 export function useJudges(projectSlug: string | undefined) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getJudges(projectSlug ?? '');
   return useQueryWithErrorToast({
     queryKey: getJudgesQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch judges');
       }

--- a/ui/src/hooks/useModelHeadToHeadStats.ts
+++ b/ui/src/hooks/useModelHeadToHeadStats.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function getModelHeadToHeadStatsQueryKey(projectSlug: string, modelId?: number) {
   return urlAsQueryKey(API_ROUTES.getHeadToHeadStats(projectSlug, modelId ?? -1));
@@ -20,11 +21,12 @@ type Params = {
   modelId?: number;
 };
 export function useModelHeadToHeadStats({ projectSlug, modelId }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getHeadToHeadStats(projectSlug ?? '', modelId ?? -1);
   return useQuery({
     queryKey: getModelHeadToHeadStatsQueryKey(projectSlug ?? '', modelId),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch head-to-head stats');
       }

--- a/ui/src/hooks/useModelResponses.ts
+++ b/ui/src/hooks/useModelResponses.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export type ModelResponse = {
   prompt: string;
@@ -11,11 +12,12 @@ type Params = {
   modelId?: number;
 };
 export function useModelResponses({ projectSlug, modelId }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getModelResponses(projectSlug ?? '', modelId ?? -1);
   return useQuery({
     queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch model responses');
       }

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -1,5 +1,6 @@
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function getModelsQueryKey(projectSlug: string) {
   return urlAsQueryKey(API_ROUTES.getModels(projectSlug));
@@ -17,11 +18,12 @@ export type Model = {
 };
 
 export function useModels(projectSlug: string | undefined) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getModels(projectSlug ?? '');
   return useQueryWithErrorToast({
     queryKey: getModelsQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch models');
       }

--- a/ui/src/hooks/useModelsRankedByJudge.ts
+++ b/ui/src/hooks/useModelsRankedByJudge.ts
@@ -1,13 +1,15 @@
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
 import { Model } from './useModels.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function useModelsRankedByJudge(projectSlug: string | undefined, judgeId: number | undefined) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getModelsRankedByJudge(projectSlug ?? '', judgeId ?? -1);
   return useQueryWithErrorToast({
     queryKey: urlAsQueryKey(url),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch models ranked by judge');
       }

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -1,5 +1,6 @@
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
+import {useApiFetch} from "./useApiFetch.ts";
 
 export function getProjectsQueryKey() {
   return urlAsQueryKey(API_ROUTES.getProjects());
@@ -12,10 +13,11 @@ export type Project = {
 };
 
 export function useProjects() {
+  const { apiFetch } = useApiFetch();
   return useQueryWithErrorToast({
     queryKey: getProjectsQueryKey(),
     queryFn: async () => {
-      const response = await fetch(API_ROUTES.getProjects());
+      const response = await apiFetch(API_ROUTES.getProjects());
       if (!response.ok) {
         throw new Error('Failed to fetch projects');
       }

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -1,6 +1,6 @@
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { useQueryWithErrorToast } from './useQueryWithErrorToast.ts';
-import {useApiFetch} from "./useApiFetch.ts";
+import { useApiFetch } from './useApiFetch.ts';
 
 export function getProjectsQueryKey() {
   return urlAsQueryKey(API_ROUTES.getProjects());

--- a/ui/src/hooks/useRecomputeLeaderboard.ts
+++ b/ui/src/hooks/useRecomputeLeaderboard.ts
@@ -2,18 +2,20 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useRecomputeLeaderboard({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.reseedEloScores(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'PUT' });
+      const response = await apiFetch(url, { method: 'PUT' });
       if (!response.ok) {
         throw new Error('Failed to recompute leaderboard rankings');
       }

--- a/ui/src/hooks/useSubmitHeadToHeadVote.ts
+++ b/ui/src/hooks/useSubmitHeadToHeadVote.ts
@@ -1,6 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey } from './useModels.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type HeadToHeadVoteRequest = {
   response_a_id: number;
@@ -13,12 +14,13 @@ type Params = {
   options?: UseMutationOptions<void, Error, HeadToHeadVoteRequest>;
 };
 export function useSubmitHeadToHeadVote({ projectSlug, options }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.submitHeadToHeadVote(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: HeadToHeadVoteRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -13,6 +13,7 @@ export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQ
   const url = API_ROUTES.getTaskStream(projectSlug, task.id);
   const queryKey = urlAsQueryKey(url);
 
+  // TODO: bearer token
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -1,7 +1,7 @@
-import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useQuery, useQueryClient, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { Task } from './useTasks.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
@@ -9,16 +9,16 @@ type Params = {
   options?: Partial<UseQueryOptions<Task, Error>>;
 };
 export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQueryResult<Task, Error> {
+  const { apiFetchEventSource } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.getTaskStream(projectSlug, task.id);
   const queryKey = urlAsQueryKey(url);
 
-  // TODO: bearer token
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       let latest = task;
-      await fetchEventSource(url, {
+      await apiFetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
         signal,

--- a/ui/src/hooks/useTasks.ts
+++ b/ui/src/hooks/useTasks.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 export function getTasksQueryKey(projectSlug: string) {
   return urlAsQueryKey(API_ROUTES.getTasks(projectSlug));
@@ -19,11 +20,12 @@ type Params = {
   options?: Partial<UseQueryOptions<Task[]>>;
 };
 export function useTasks({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.getTasks(projectSlug ?? '');
   return useQuery({
     queryKey: getTasksQueryKey(projectSlug ?? ''),
     queryFn: async () => {
-      const response = await fetch(url);
+      const response = await apiFetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch tasks');
       }

--- a/ui/src/hooks/useTriggerAutoJudge.ts
+++ b/ui/src/hooks/useTriggerAutoJudge.ts
@@ -2,6 +2,7 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type TriggerAutoJudgeRequest = {
   judge_ids: number[];
@@ -14,11 +15,12 @@ type Params = {
   options?: UseMutationOptions<void, Error, TriggerAutoJudgeRequest>;
 };
 export function useTriggerAutoJudge({ projectSlug, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.triggerAutoJudge(projectSlug);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async (request: TriggerAutoJudgeRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'POST',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useTriggerModelAutoJudge.ts
+++ b/ui/src/hooks/useTriggerModelAutoJudge.ts
@@ -2,6 +2,7 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { taskStatusToColor } from '../lib/tasks.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
@@ -9,11 +10,12 @@ type Params = {
   options?: UseMutationOptions<void, Error, void>;
 };
 export function useTriggerModelAutoJudge({ projectSlug, modelId, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const url = API_ROUTES.triggerModelAutoJudge(projectSlug, modelId ?? -1);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'POST'),
     mutationFn: async () => {
-      const response = await fetch(url, { method: 'POST' });
+      const response = await apiFetch(url, { method: 'POST' });
       if (!response.ok) {
         throw new Error('Failed to start automated judgement for model');
       }

--- a/ui/src/hooks/useUpdateJudge.ts
+++ b/ui/src/hooks/useUpdateJudge.ts
@@ -1,6 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getJudgesQueryKey, Judge } from './useJudges.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type UpdateJudgeRequest = {
   enabled: boolean;
@@ -12,12 +13,13 @@ type Params = {
   options?: UseMutationOptions<Judge, Error, UpdateJudgeRequest>;
 };
 export function useUpdateJudge({ projectSlug, judgeId, options = {} }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.updateJudge(projectSlug, judgeId);
   return useMutation({
     mutationKey: urlAsQueryKey(url, 'PUT'),
     mutationFn: async (request: UpdateJudgeRequest) => {
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: 'PUT',
         body: JSON.stringify(request),
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/hooks/useUploadModelResponses.ts
+++ b/ui/src/hooks/useUploadModelResponses.ts
@@ -4,12 +4,14 @@ import { zip } from 'ramda';
 import { API_ROUTES, urlAsQueryKey } from '../lib/routes.ts';
 import { getModelsQueryKey, Model } from './useModels.ts';
 import { getTasksQueryKey } from './useTasks.ts';
+import { useApiFetch } from './useApiFetch.ts';
 
 type Params = {
   projectSlug: string;
   options?: UseMutationOptions<Model[], Error, [File[], string[]]>;
 };
 export function useUploadModelResponses({ projectSlug, options }: Params) {
+  const { apiFetch } = useApiFetch();
   const queryClient = useQueryClient();
   const url = API_ROUTES.uploadModelResponses(projectSlug);
   return useMutation({
@@ -23,7 +25,7 @@ export function useUploadModelResponses({ projectSlug, options }: Params) {
         formData.append(file.name, file);
         formData.append(`${file.name}||model_name`, modelName); // format here is enforced by backend
       });
-      const response = await fetch(url, { method: 'POST', body: formData });
+      const response = await apiFetch(url, { method: 'POST', body: formData });
       if (!response.ok) {
         throw new Error('Failed to add model responses');
       }


### PR DESCRIPTION
When compiled in cloud mode, attach a bearer token from Auth0 to all requests that hit the API.

Does not change normal local app behavior.