### PR TITLE
Handle empty input to `fixing_wrapper`

### DIFF
--- a/autoarena/judge/wrapper.py
+++ b/autoarena/judge/wrapper.py
@@ -69,6 +69,8 @@ def fixing_wrapper(judge_class: type[T]) -> type[T]:
 
         def judge(self, prompt: str, response_a: str, response_b: str) -> str:
             winner_raw = super().judge(prompt, response_a, response_b)
+            if winner_raw == "":
+                return self.CLASS_TO_WINNER[self.TIE]
             winner = clean_judgement(winner_raw)
             if winner not in ACCEPTABLE_RESPONSES:
                 classifications = self.pipe(winner_raw, candidate_labels=self.CLASSES)

--- a/tests/integration/judge/test_wrapper.py
+++ b/tests/integration/judge/test_wrapper.py
@@ -14,9 +14,10 @@ from tests.unit.judge.conftest import DummyJudge
         ("A is better.", "A"),
         ("Response B is better, because it does a better job than A.", "B"),
         ("Neither A nor B are that good.", "-"),
+        ("", "-"),  # empty responses are properly marked as ties
     ],
 )
-def test__fixing_judge(raw: str, expected: str) -> None:
+def test__fixing_wrapper(raw: str, expected: str) -> None:
     test_judge = fixing_wrapper(DummyJudge)("dummy", "dummy", "description")
     test_judge.winners = [raw]
     assert test_judge.judge("p", "a", "b") == expected


### PR DESCRIPTION
The `fixing_wrapper`'s HF transformers `pipeline` fails with an empty input. Rather than passing this to the pipeline, bail early and classify it as a tie. Verified by new test.