### PR TITLE
Show only first and last N log messages in tasks drawer by default

### DIFF
--- a/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
+++ b/ui/src/components/TasksDrawer/TaskAccordionItem.tsx
@@ -1,10 +1,13 @@
 import moment from 'moment/moment';
 import { IconBooks, IconCalculator, IconGavel } from '@tabler/icons-react';
-import { Accordion, Badge, Code, Group, Progress, Stack, Text } from '@mantine/core';
+import { Accordion, Badge, Button, Code, Group, Progress, Stack, Text } from '@mantine/core';
+import { useMemo, useState } from 'react';
 import { Task } from '../../hooks/useTasks.ts';
 import { taskIsDone, taskStatusToColor, taskStatusToLabel } from '../../lib/tasks.ts';
 import { useTaskStream } from '../../hooks/useTaskStream.ts';
 import { useUrlState } from '../../hooks/useUrlState.ts';
+
+const N_LOG_LINES_DEFAULT = 30;
 
 type Props = {
   task: Task;
@@ -16,6 +19,7 @@ export function TaskAccordionItem({ task: inputTask }: Props) {
     task: inputTask,
     options: { enabled: !taskIsDone(inputTask.status) },
   });
+  const [showFullLogs, setShowFullLogs] = useState(false);
 
   const slug = `${task.task_type}-${moment(task.created).format('YYYYMMDD-hhmmss-SSS')}`;
   const IconComponent =
@@ -36,6 +40,15 @@ export function TaskAccordionItem({ task: inputTask }: Props) {
       : task.task_type === 'auto-judge'
         ? 'var(--mantine-color-orange-6)'
         : 'var(--mantine-color-green-6)';
+
+  const [startLogs, endLogs]: [string[], string[]] = useMemo(() => {
+    const logLines = task.logs.split('\n');
+    if (showFullLogs || logLines.length <= N_LOG_LINES_DEFAULT) {
+      return [logLines, []];
+    }
+    const halfLines = N_LOG_LINES_DEFAULT / 2;
+    return [logLines.slice(0, halfLines), logLines.slice(logLines.length - halfLines, logLines.length)];
+  }, [task.logs, showFullLogs]);
 
   return (
     <Accordion.Item value={slug}>
@@ -61,19 +74,35 @@ export function TaskAccordionItem({ task: inputTask }: Props) {
             animated={!taskIsDone(task.status)}
           />
           <Code block fs="xs">
-            {task.logs.split('\n').map((line, i) => (
-              <Text inherit key={i}>
-                <Text span inherit c="dimmed">
-                  {line.slice(0, 21)}
-                </Text>
-                <Text span inherit>
-                  {line.slice(21, line.length)}
-                </Text>
-              </Text>
+            {startLogs.map((line, i) => (
+              <LogLine key={i} line={line} />
             ))}
+            {endLogs.length > 0 && (
+              <>
+                <Button color="gray" variant="subtle" size="xs" m={8} onClick={() => setShowFullLogs(true)}>
+                  Show full logs
+                </Button>
+                {endLogs.map((line, i) => (
+                  <LogLine key={`end-${i}`} line={line} />
+                ))}
+              </>
+            )}
           </Code>
         </Stack>
       </Accordion.Panel>
     </Accordion.Item>
+  );
+}
+
+function LogLine({ line }: { line: string }) {
+  return (
+    <Text inherit>
+      <Text span inherit c="dimmed">
+        {line.slice(0, 21)}
+      </Text>
+      <Text span inherit>
+        {line.slice(21, line.length)}
+      </Text>
+    </Text>
   );
 }


### PR DESCRIPTION
Make it easier to follow along with active tasks that probably have a lot of `Judged N of M with 'X'` filler messages in the middle by showing only the first and last N log messages for tasks with lots of logs:

<img width="764" alt="Screenshot 2024-09-18 at 2 41 13 PM" src="https://github.com/user-attachments/assets/cc91f176-bd12-4525-a964-dd7113343a4a">

