### PR TITLE
Replace internal `<Anchor>` elements with `<Link>` for client-side routing

### DIFF
--- a/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
+++ b/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
@@ -1,6 +1,7 @@
-import { Anchor, Code, Modal, Select, Stack, Text } from '@mantine/core';
+import { Code, Modal, Select, Stack, Text } from '@mantine/core';
 import { useMemo, useState } from 'react';
 import moment from 'moment';
+import { Link } from 'react-router-dom';
 import { useUrlState } from '../../hooks/useUrlState.ts';
 import { pluralize } from '../../lib/string.ts';
 import { useCreateFineTuningTask } from '../../hooks/useCreateFineTuningTask.ts';
@@ -49,8 +50,13 @@ export function CreateFineTunedJudgeModal({ isOpen, onClose }: Props) {
       <Stack>
         <Text size="sm">
           Start a <b>fine-tuning job</b> to create a custom judge model using the {pluralize(nVotes, 'manual vote')}{' '}
-          submitted on the <Anchor href={ROUTES.compare(projectSlug)}>Head-to-Head</Anchor> tab within the{' '}
-          <Code>{project?.slug}</Code> project.
+          submitted on the{' '}
+          <Link to={ROUTES.compare(projectSlug)} style={{ textDecoration: 'none' }}>
+            <Text span c="kolena">
+              Head-to-Head
+            </Text>
+          </Link>{' '}
+          tab within the <Code>{project?.slug}</Code> project.
         </Text>
         <Select
           label="Base Model"

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -10,6 +10,7 @@ import {
   IconUser,
 } from '@tabler/icons-react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { Link } from 'react-router-dom';
 import { useAppMode } from '../hooks/useAppMode.ts';
 import { ExternalUrls } from '../lib/urls.ts';
 import { ROUTES } from '../lib/routes.ts';
@@ -34,9 +35,9 @@ export function MainMenu() {
       </Menu.Target>
 
       <Menu.Dropdown>
-        <Anchor href={ROUTES.home()} underline="never">
+        <Link to={ROUTES.home()} style={{ textDecoration: 'none' }}>
           <Menu.Item leftSection={<IconHome {...iconProps} />}>Home</Menu.Item>
-        </Anchor>
+        </Link>
         <Anchor href={ExternalUrls.AUTOARENA_GITHUB} underline="never" target="_blank">
           <Menu.Item leftSection={<IconBrandGithub {...iconProps} />}>Repository</Menu.Item>
         </Anchor>

--- a/ui/src/components/OnboardingTimeline.tsx
+++ b/ui/src/components/OnboardingTimeline.tsx
@@ -1,9 +1,10 @@
-import { Timeline, Text, Paper, Title, Stack, Group, Button, Anchor, Code, CloseButton, Divider } from '@mantine/core';
+import { Timeline, Text, Paper, Title, Stack, Group, Button, Code, CloseButton, Divider } from '@mantine/core';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { IconGavel, IconPlus, IconRobot } from '@tabler/icons-react';
 import { prop, sortBy } from 'ramda';
 import moment, { MomentInput } from 'moment';
 import { notifications } from '@mantine/notifications';
+import { Link } from 'react-router-dom';
 import { Judge, useJudges } from '../hooks/useJudges.ts';
 import { useUrlState } from '../hooks/useUrlState.ts';
 import { Model, useModels } from '../hooks/useModels.ts';
@@ -154,11 +155,11 @@ export function OnboardingTimeline({ dismissable = true }: Props) {
                 timestamp={firstJudge?.created}
                 action={
                   activeStage === 1 ? (
-                    <Anchor href={ROUTES.judges(projectSlug ?? '')}>
+                    <Link to={ROUTES.judges(projectSlug ?? '')}>
                       <Button leftSection={<IconGavel size={18} />} size="xs">
                         Configure Judge
                       </Button>
-                    </Anchor>
+                    </Link>
                   ) : undefined
                 }
               />


### PR DESCRIPTION
Prevents a flicker from reloading the various hooks necessary to populate a page.