### PR TITLE
Refetch projects when opening selector

### DIFF
--- a/ui/src/components/ProjectSelect.tsx
+++ b/ui/src/components/ProjectSelect.tsx
@@ -21,7 +21,6 @@ export function ProjectSelect() {
     queryCilent.invalidateQueries({ queryKey: getProjectsQueryKey() });
   }
 
-  // TODO: this can be simplified now that slugs are IDs are strings
   return (
     <Group gap="xs">
       <Select

--- a/ui/src/components/ProjectSelect.tsx
+++ b/ui/src/components/ProjectSelect.tsx
@@ -1,18 +1,24 @@
 import { Group, Select } from '@mantine/core';
 import { useMemo } from 'react';
-import { useProjects } from '../hooks/useProjects.ts';
+import { useQueryClient } from '@tanstack/react-query';
+import { getProjectsQueryKey, useProjects } from '../hooks/useProjects.ts';
 import { useUrlState } from '../hooks/useUrlState.ts';
 import { useProject } from '../hooks/useProject.ts';
 import { CreateProjectButton } from './CreateProjectButton.tsx';
 
 export function ProjectSelect() {
   const { projectSlug, setProjectSlug } = useUrlState();
+  const queryCilent = useQueryClient();
   const { data: projects } = useProjects();
   const { data: currentProject } = useProject(projectSlug);
   const allProjectSlugs = useMemo(() => (projects ?? []).map(({ slug }) => slug), [projects]);
 
   function handleSelectProject(projectSlug: string | null) {
     setProjectSlug(projectSlug ?? null);
+  }
+
+  function handleRefetchProjects() {
+    queryCilent.invalidateQueries({ queryKey: getProjectsQueryKey() });
   }
 
   // TODO: this can be simplified now that slugs are IDs are strings
@@ -25,6 +31,7 @@ export function ProjectSelect() {
         value={currentProject?.slug ?? null}
         onChange={handleSelectProject}
         disabled={allProjectSlugs.length < 1}
+        onDropdownOpen={handleRefetchProjects}
       />
       <CreateProjectButton small />
     </Group>


### PR DESCRIPTION
Minor QoL improvement to refetch the list of projects when you open the selector. No longer require a page refresh to pick up a new project that you have placed in your `data` directory.