### PR TITLE
Use RQ to control SSE stream retries

### DIFF
--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -144,6 +144,7 @@ def router() -> APIRouter:
         project_slug: str,
         timeout: Optional[float] = None,
     ) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
+        raise RuntimeError
         return SSEStreamingResponse(TaskService.has_active_stream(project_slug, timeout=timeout))
 
     @r.delete("/project/{project_slug}/tasks/completed")

--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -144,7 +144,6 @@ def router() -> APIRouter:
         project_slug: str,
         timeout: Optional[float] = None,
     ) -> StreamingResponse:  # Iterator[api.HasActiveTasks]
-        raise RuntimeError
         return SSEStreamingResponse(TaskService.has_active_stream(project_slug, timeout=timeout))
 
     @r.delete("/project/{project_slug}/tasks/completed")

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -63,7 +63,7 @@ class TaskService:
             if prev != cur:
                 yield cur
             prev = cur
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.2)
 
     @staticmethod
     def create(project_slug: str, task_type: api.TaskType, log: str = "Started") -> api.Task:

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -12,6 +12,7 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
+      console.log('trying');
       await apiFetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },
@@ -19,6 +20,9 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
         onmessage: event => {
           const parsedData: { has_active: boolean } = JSON.parse(event.data);
           queryClient.setQueryData(queryKey, parsedData.has_active);
+        },
+        onerror: () => {
+          throw new Error('Failed to fetch active task stream'); // without this, fetchEventSource retries indefinitely
         },
       });
       return false; // shouldn't get here

--- a/ui/src/hooks/useHasActiveTasksStream.ts
+++ b/ui/src/hooks/useHasActiveTasksStream.ts
@@ -12,7 +12,6 @@ export function useHasActiveTasksStream(projectSlug?: string): UseQueryResult<bo
   return useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
-      console.log('trying');
       await apiFetchEventSource(url, {
         method: 'GET',
         headers: { Accept: 'text/event-stream' },

--- a/ui/src/hooks/useTaskStream.ts
+++ b/ui/src/hooks/useTaskStream.ts
@@ -27,6 +27,9 @@ export function useTaskStream({ projectSlug, task, options = {} }: Params): UseQ
           latest = parsedData;
           queryClient.setQueryData(queryKey, parsedData);
         },
+        onerror: () => {
+          throw new Error('Failed to fetch task stream');
+        },
       });
       return latest;
     },


### PR DESCRIPTION
Use the same retry/control mechanism that is used for other fetches (React-Query's `useQuery` handling) for event source stream fetches, rather than the retry mechanism built into `fetchEventSource`.