### PR TITLE
Use SQLite instead of DuckDB for project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AutoArena requires two pieces of information to test a model: the input `prompt`
 
 ### 📂 Data Storage
 
-Data is stored in `./data/<project>.duckdb` files in the directory where you invoked AutoArena. See
+Data is stored in `./data/<project>.sqlite` files in the directory where you invoked AutoArena. See
 [`data/README.md`](./data/README.md) for more details on data storage in AutoArena.
 
 ## 🦾 Development

--- a/autoarena/judge/wrapper.py
+++ b/autoarena/judge/wrapper.py
@@ -6,6 +6,7 @@ from tenacity import retry, stop_after_attempt, RetryCallState, wait_exponential
 
 from autoarena.judge.base import AutomatedJudge
 from autoarena.judge.utils import ACCEPTABLE_RESPONSES
+from autoarena.store.utils import invert_winner
 
 JudgeWrapper = Callable[[type[AutomatedJudge]], type[AutomatedJudge]]
 T = TypeVar("T", bound=AutomatedJudge)
@@ -20,11 +21,7 @@ def ab_shuffling_wrapper(judge_class: type[T]) -> type[T]:
             shuffled = np.random.randint(2) == 0
             ra, rb = (response_b, response_a) if shuffled else (response_a, response_b)
             winner = super().judge(prompt, ra, rb)
-            return self._unshuffle_winner(winner) if shuffled else winner
-
-        @staticmethod
-        def _unshuffle_winner(winner: str) -> str:
-            return "B" if winner == "A" else "A" if winner == "B" else "-"
+            return invert_winner(winner) if shuffled else winner
 
     return ABShufflingJudge
 

--- a/autoarena/service/elo.py
+++ b/autoarena/service/elo.py
@@ -51,7 +51,7 @@ class EloService:
     def reseed_scores(project_slug: str, config: EloConfig = DEFAULT_ELO_CONFIG) -> None:
         df_h2h = EloService.get_df_head_to_head(project_slug)
         df_elo = EloService.compute_elo(df_h2h, config=config)  # noqa: F841
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             with temporary_table(conn, df_elo) as tmp:
                 conn.cursor().execute(
                     f"""

--- a/autoarena/service/elo.py
+++ b/autoarena/service/elo.py
@@ -56,7 +56,7 @@ class EloService:
                 conn.cursor().execute(
                     """
                     UPDATE model
-                    SET elo = IFNULL(df_elo.elo, $default_elo), q025 = df_elo.q025, q975 = df_elo.q975
+                    SET elo = IFNULL(df_elo.elo, :default_elo), q025 = df_elo.q025, q975 = df_elo.q975
                     FROM model m2
                     LEFT JOIN df_elo ON df_elo.model = m2.name -- left join to set null values for models without votes
                     WHERE model.id = m2.id;

--- a/autoarena/service/elo.py
+++ b/autoarena/service/elo.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from autoarena.api import api
 from autoarena.service.project import ProjectService
+from autoarena.store.database import temp_table
 
 
 @dataclass(frozen=True)
@@ -25,7 +26,7 @@ class EloService:
     @staticmethod
     def get_df_head_to_head(project_slug: str) -> pd.DataFrame:
         with ProjectService.connect(project_slug) as conn:
-            return conn.execute(
+            return pd.read_sql_query(
                 """
                 SELECT
                     j.id AS judge_id,
@@ -42,24 +43,26 @@ class EloService:
                 JOIN model ma ON ra.model_id = ma.id
                 JOIN model mb ON rb.model_id = mb.id
                 ORDER BY h.id -- ensure we are replaying head-to-heads in the order they were submitted
-            """,
-            ).df()
+                """,
+                conn,
+            )
 
     @staticmethod
     def reseed_scores(project_slug: str, config: EloConfig = DEFAULT_ELO_CONFIG) -> None:
         df_h2h = EloService.get_df_head_to_head(project_slug)
         df_elo = EloService.compute_elo(df_h2h, config=config)  # noqa: F841
-        with ProjectService.connect(project_slug) as conn:
-            conn.execute(
-                """
-                UPDATE model
-                SET elo = IFNULL(df_elo.elo, $default_elo), q025 = df_elo.q025, q975 = df_elo.q975
-                FROM model m2
-                LEFT JOIN df_elo ON df_elo.model = m2.name -- left join to set null values for any models without votes
-                WHERE model.id = m2.id;
-                """,
-                dict(default_elo=config.default_score),
-            )
+        with ProjectService.connect(project_slug, autocommit=True) as conn:
+            with temp_table(conn, df_elo, "df_elo"):
+                conn.cursor().execute(
+                    """
+                    UPDATE model
+                    SET elo = IFNULL(df_elo.elo, $default_elo), q025 = df_elo.q025, q975 = df_elo.q975
+                    FROM model m2
+                    LEFT JOIN df_elo ON df_elo.model = m2.name -- left join to set null values for models without votes
+                    WHERE model.id = m2.id;
+                    """,
+                    dict(default_elo=config.default_score),
+                )
 
     # most elo-related code is from https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/monitor/elo_analysis.py
     @staticmethod

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -153,7 +153,7 @@ class HeadToHeadService:
         df_h2h_deduped = df_h2h_deduped.drop_duplicates(subset=["response_id_slug", "judge_id"], keep="first")
         if len(df_h2h_deduped) != len(df_h2h):
             logger.warning(f"Dropped {len(df_h2h) - len(df_h2h_deduped)} duplicate rows before uploading")
-        with ProjectService.connect(project_slug) as conn:
+        with ProjectService.connect(project_slug, autocommit=True) as conn:
             with temp_table(conn, df_h2h_deduped, "df_h2h_deduped"):
                 conn.execute("""
                     INSERT INTO head_to_head (response_id_slug, response_a_id, response_b_id, judge_id, winner)

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -84,9 +84,9 @@ class HeadToHeadService:
         with ProjectService.connect(project_slug) as conn:
             ((n_h2h,),) = conn.execute(
                 """
-                SELECT COUNT(DISTINCT id_slug(ra.id, rb.id))
+                SELECT COUNT(1) / 2
                 FROM response ra
-                JOIN response rb ON ra.prompt = rb.prompt AND ra.model_id != rb.model_id
+                JOIN response rb ON ra.id != rb.id AND ra.prompt = rb.prompt AND ra.model_id != rb.model_id
                 """,
             ).fetchall()
         return n_h2h

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -105,10 +105,10 @@ class HeadToHeadService:
                 INSERT INTO head_to_head (response_id_slug, response_a_id, response_b_id, judge_id, winner)
                 SELECT :response_id_slug, :response_a_id, :response_b_id, j.id, :winner
                 FROM judge j
-                WHERE j.judge_type = $judge_type
+                WHERE j.judge_type = :judge_type
                 ON CONFLICT (response_id_slug, judge_id) DO UPDATE SET
                     winner = IIF(
-                        response_a_id = $response_b_id,
+                        response_a_id = :response_b_id,
                         IIF(EXCLUDED.winner = 'A', 'B', IIF(EXCLUDED.winner = 'B', 'A', EXCLUDED.winner)), -- invert
                         EXCLUDED.winner
                     )

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -96,7 +96,7 @@ class HeadToHeadService:
 
     @staticmethod
     def submit_vote(project_slug: str, request: api.HeadToHeadVoteRequest) -> None:
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             cur = conn.cursor()
 
             # 1. insert head-to-head record
@@ -153,7 +153,7 @@ class HeadToHeadService:
         df_h2h_deduped = df_h2h_deduped.drop_duplicates(subset=["response_id_slug", "judge_id"], keep="first")
         if len(df_h2h_deduped) != len(df_h2h):
             logger.warning(f"Dropped {len(df_h2h) - len(df_h2h_deduped)} duplicate rows before uploading")
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             with temporary_table(conn, df_h2h_deduped) as tmp:
                 conn.execute(f"""
                     INSERT INTO head_to_head (response_id_slug, response_a_id, response_b_id, judge_id, winner)

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -125,7 +125,7 @@ class JudgeService:
     def update(project_slug: str, judge_id: int, request: api.UpdateJudgeRequest) -> api.Judge:
         with ProjectService.connect(project_slug, autocommit=True) as conn:
             conn.cursor().execute(
-                "UPDATE judge SET enabled = $enabled WHERE id = $judge_id",
+                "UPDATE judge SET enabled = :enabled WHERE id = :judge_id",
                 dict(judge_id=judge_id, enabled=request.enabled),
             )
         return [j for j in JudgeService.get_all(project_slug) if j.id == judge_id][0]
@@ -133,8 +133,7 @@ class JudgeService:
     @staticmethod
     def delete(project_slug: str, judge_id: int) -> None:
         with ProjectService.connect(project_slug, autocommit=True) as conn:
-            conn.execute("DELETE FROM head_to_head WHERE judge_id = $judge_id", dict(judge_id=judge_id))
-            conn.execute("DELETE FROM judge WHERE id = $judge_id", dict(judge_id=judge_id))
+            conn.execute("DELETE FROM judge WHERE id = :judge_id", dict(judge_id=judge_id))
 
     @staticmethod
     def check_can_access(judge_type: api.JudgeType) -> bool:

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -75,24 +75,21 @@ class JudgeService:
     @staticmethod
     def create(project_slug: str, request: api.CreateJudgeRequest) -> api.Judge:
         with ProjectService.connect(project_slug, autocommit=True) as conn:
-            ((judge_id, created, enabled),) = (
-                conn.cursor()
-                .execute(
-                    """
+            cur = conn.cursor()
+            ((judge_id, created, enabled),) = cur.execute(
+                """
                 INSERT INTO judge (judge_type, name, model_name, system_prompt, description, enabled)
                 VALUES (:judge_type, :name, :model_name, :system_prompt, :description, TRUE)
                 RETURNING id, created, enabled
-            """,
-                    dict(
-                        judge_type=request.judge_type.value,
-                        name=request.name,
-                        model_name=request.model_name,
-                        system_prompt=request.system_prompt,
-                        description=request.description,
-                    ),
-                )
-                .fetchall()
-            )
+                """,
+                dict(
+                    judge_type=request.judge_type.value,
+                    name=request.name,
+                    model_name=request.model_name,
+                    system_prompt=request.system_prompt,
+                    description=request.description,
+                ),
+            ).fetchall()
         return api.Judge(
             id=judge_id,
             judge_type=request.judge_type,

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -74,7 +74,7 @@ class JudgeService:
 
     @staticmethod
     def create(project_slug: str, request: api.CreateJudgeRequest) -> api.Judge:
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             cur = conn.cursor()
             ((judge_id, created, enabled),) = cur.execute(
                 """
@@ -105,7 +105,7 @@ class JudgeService:
     # TODO: is this necessary?
     @staticmethod
     def create_human_judge(project_slug: str) -> api.Judge:
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             conn.cursor().execute(
                 """
                 INSERT INTO judge (judge_type, name, description, enabled)
@@ -123,7 +123,7 @@ class JudgeService:
 
     @staticmethod
     def update(project_slug: str, judge_id: int, request: api.UpdateJudgeRequest) -> api.Judge:
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             conn.cursor().execute(
                 "UPDATE judge SET enabled = :enabled WHERE id = :judge_id",
                 dict(judge_id=judge_id, enabled=request.enabled),
@@ -132,7 +132,7 @@ class JudgeService:
 
     @staticmethod
     def delete(project_slug: str, judge_id: int) -> None:
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             conn.execute("DELETE FROM judge WHERE id = :judge_id", dict(judge_id=judge_id))
 
     @staticmethod

--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -6,7 +6,7 @@ from autoarena.api import api
 from autoarena.error import NotFoundError, BadRequestError
 from autoarena.service.elo import EloService, DEFAULT_ELO_CONFIG
 from autoarena.service.project import ProjectService
-from autoarena.store.database import temp_table
+from autoarena.store.database import temporary_table
 from autoarena.store.utils import check_required_columns
 
 
@@ -109,11 +109,11 @@ class ModelService:
                 .fetchall()
             )
             df_response["model_id"] = new_model_id
-            with temp_table(conn, df_response, "df_response"):
-                conn.execute("""
+            with temporary_table(conn, df_response) as tmp:
+                conn.execute(f"""
                     INSERT INTO response (model_id, prompt, response)
                     SELECT model_id, prompt, response
-                    FROM df_response
+                    FROM {tmp}
                 """)
         models = ModelService.get_all(project_slug)
         new_model = [model for model in models if model.id == new_model_id][0]

--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -99,7 +99,7 @@ class ModelService:
         if len(df_response) != n_input:
             logger.warning(f"Dropped {n_input - len(df_response)} responses with empty prompt or response values")
         logger.info(f"Uploading {len(df_response)} responses from model '{model_name}'")
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             ((new_model_id,),) = (
                 conn.cursor()
                 .execute(
@@ -122,7 +122,7 @@ class ModelService:
     @staticmethod
     def delete(project_slug: str, model_id: int) -> None:
         params = dict(model_id=model_id)
-        with ProjectService.connect(project_slug, autocommit=True) as conn:
+        with ProjectService.connect(project_slug, commit=True) as conn:
             conn.execute("DELETE FROM model WHERE id = :model_id", params)  # let cascading deletes handle the rest
 
     @staticmethod

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -77,7 +77,7 @@ class ProjectService:
                     cur = conn.cursor()
                     cur.executescript(migration.read_text())
                     cur.execute(
-                        "INSERT INTO migration (migration_index, filename) VALUES ($index, $filename)",
+                        "INSERT INTO migration (migration_index, filename) VALUES (:index, :filename)",
                         dict(index=int(migration.name.split("__")[0]), filename=migration.name),
                     )
             except Exception as e:

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -13,11 +13,11 @@ from autoarena.store.database import get_database_connection, get_available_migr
 class ProjectService:
     @staticmethod
     @contextmanager
-    def connect(slug: str, autocommit: bool = False) -> Iterator[sqlite3.Connection]:
+    def connect(slug: str, commit: bool = False) -> Iterator[sqlite3.Connection]:
         path = ProjectService._slug_to_path(slug)
         if not path.exists():
             raise NotFoundError(f"File for project '{slug}' not found (expected: {path})")
-        with get_database_connection(path, autocommit=autocommit) as conn:
+        with get_database_connection(path, commit=commit) as conn:
             yield conn
 
     @staticmethod
@@ -72,7 +72,7 @@ class ProjectService:
             if migration.name in applied_migrations:
                 continue
             try:
-                with get_database_connection(path, autocommit=True) as conn:
+                with get_database_connection(path, commit=True) as conn:
                     logger.info(f"Applying migration '{migration.name}' to '{path.name}'")
                     cur = conn.cursor()
                     cur.executescript(migration.read_text())
@@ -91,7 +91,6 @@ class ProjectService:
                 cur = conn.cursor()
                 cur.execute("SELECT migration_index, filename FROM migration ORDER BY migration_index")
                 return cur.fetchall()
-        # TODO: what exception should this be?
         except sqlite3.OperationalError:
             return []  # database is new and does not have a migration table
 

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -1,27 +1,29 @@
+import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
-import duckdb
 from loguru import logger
 
 from autoarena.api import api
 from autoarena.error import NotFoundError, MigrationError
-from autoarena.store.database import get_database_connection, get_available_migrations, DataDirectoryProvider
+from autoarena.store.database import get_database_cursor, get_available_migrations, DataDirectoryProvider
 
 
 class ProjectService:
+    # TODO: rename usage to 'cursor' or something similar
     @staticmethod
     @contextmanager
-    def connect(slug: str) -> duckdb.DuckDBPyConnection:
+    def connect(slug: str) -> Iterator[sqlite3.Cursor]:
         path = ProjectService._slug_to_path(slug)
         if not path.exists():
             raise NotFoundError(f"File for project '{slug}' not found (expected: {path})")
-        with get_database_connection(path) as conn:
+        with get_database_cursor(path) as conn:
             yield conn
 
     @staticmethod
     def get_all() -> list[api.Project]:
-        paths = sorted(list(DataDirectoryProvider.get().glob("*.duckdb")))
+        paths = sorted(list(DataDirectoryProvider.get().glob("*.sqlite")))
         return [api.Project(slug=ProjectService._path_to_slug(p), filename=p.name, filepath=str(p)) for p in paths]
 
     @staticmethod
@@ -31,7 +33,7 @@ class ProjectService:
 
         data_directory = DataDirectoryProvider.get()
         data_directory.mkdir(parents=True, exist_ok=True)
-        path = data_directory / f"{request.name}.duckdb"
+        path = data_directory / f"{request.name}.sqlite"
         slug = ProjectService._path_to_slug(path)
         ProjectService._setup_database(path)
         JudgeService.create_human_judge(slug)
@@ -56,7 +58,7 @@ class ProjectService:
 
     @staticmethod
     def _slug_to_path(slug: str) -> Path:
-        return DataDirectoryProvider.get() / f"{slug}.duckdb"
+        return DataDirectoryProvider.get() / f"{slug}.sqlite"
 
     @staticmethod
     def _setup_database(path: Path) -> None:
@@ -71,9 +73,9 @@ class ProjectService:
             if migration.name in applied_migrations:
                 continue
             try:
-                with get_database_connection(path) as conn:
+                with get_database_cursor(path) as conn:
                     logger.info(f"Applying migration '{migration.name}' to '{path.name}'")
-                    conn.sql(migration.read_text())
+                    conn.execute(migration.read_text())
                     conn.execute(
                         "INSERT INTO migration (migration_index, filename) VALUES ($index, $filename)",
                         dict(index=int(migration.name.split("__")[0]), filename=migration.name),
@@ -85,10 +87,11 @@ class ProjectService:
     @staticmethod
     def _get_applied_migrations(path: Path) -> list[tuple[int, str]]:
         try:
-            with get_database_connection(path) as conn:
+            with get_database_cursor(path) as conn:
                 conn.execute("SELECT migration_index, filename FROM migration ORDER BY migration_index")
                 return conn.fetchall()
-        except duckdb.CatalogException:
+        # TODO: what exception should this be?
+        except sqlite3.OperationalError:
             return []  # database is new and does not have a migration table
 
     # TODO: restart pending tasks rather than simply terminating

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -11,10 +11,9 @@ from autoarena.store.database import get_database_connection, get_available_migr
 
 
 class ProjectService:
-    # TODO: rename usage to 'cursor' or something similar
     @staticmethod
     @contextmanager
-    def connect(slug: str, autocommit: bool = False) -> Iterator[sqlite3.Cursor]:
+    def connect(slug: str, autocommit: bool = False) -> Iterator[sqlite3.Connection]:
         path = ProjectService._slug_to_path(slug)
         if not path.exists():
             raise NotFoundError(f"File for project '{slug}' not found (expected: {path})")

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -47,10 +47,14 @@ class TaskService:
     @staticmethod
     def has_active(project_slug: str) -> api.HasActiveTasks:
         with ProjectService.connect(project_slug) as conn:
-            records = conn.execute(
-                "SELECT 1 WHERE EXISTS (SELECT 1 FROM task WHERE status IN ($started, $in_progress))",
-                dict(started=api.TaskStatus.STARTED.value, in_progress=api.TaskStatus.IN_PROGRESS.value),
-            ).fetchall()
+            records = (
+                conn.cursor()
+                .execute(
+                    "SELECT 1 WHERE EXISTS (SELECT 1 FROM task WHERE status IN (:started, :in_progress))",
+                    dict(started=api.TaskStatus.STARTED.value, in_progress=api.TaskStatus.IN_PROGRESS.value),
+                )
+                .fetchall()
+            )
             return api.HasActiveTasks(has_active=len(records) > 0)
 
     @staticmethod
@@ -69,22 +73,29 @@ class TaskService:
 
     @staticmethod
     def create(project_slug: str, task_type: api.TaskType, log: str = "Started") -> api.Task:
-        with ProjectService.connect(project_slug) as conn:
+        with ProjectService.connect(project_slug, autocommit=True) as conn:
             logs = f"{TaskService._time_slug()} {log}"
-            ((task_id, created, progress, status, logs),) = conn.execute(
-                """
+            ((task_id, created, progress, status, logs),) = (
+                conn.cursor()
+                .execute(
+                    """
                 INSERT INTO task (task_type, status, logs)
-                VALUES ($task_type, $status, $logs)
+                VALUES (:task_type, :status, :logs)
                 RETURNING id, created, progress, status, logs
                 """,
-                dict(task_type=task_type.value, status=api.TaskStatus.STARTED.value, logs=logs),
-            ).fetchall()
+                    dict(task_type=task_type.value, status=api.TaskStatus.STARTED.value, logs=logs),
+                )
+                .fetchall()
+            )
         return api.Task(id=task_id, task_type=task_type, created=created, progress=progress, status=status, logs=logs)
 
     @staticmethod
     def delete_completed(project_slug: str) -> None:
-        with ProjectService.connect(project_slug) as conn:
-            conn.execute("TRUNCATE task")
+        with ProjectService.connect(project_slug, autocommit=True) as conn:
+            conn.cursor().execute(
+                "DELETE FROM task WHERE status IN (:completed, :failed)",
+                dict(completed=api.TaskStatus.COMPLETED.value, failed=api.TaskStatus.FAILED.value),
+            )
 
     @staticmethod
     def update(
@@ -94,9 +105,9 @@ class TaskService:
         progress: Optional[float] = None,
         status: api.TaskStatus = api.TaskStatus.IN_PROGRESS,
     ) -> None:
-        with ProjectService.connect(project_slug) as conn:
+        with ProjectService.connect(project_slug, autocommit=True) as conn:
             log = f"{TaskService._time_slug()} {log}"
-            conn.execute(
+            conn.cursor().execute(
                 """
                 UPDATE task
                 SET progress = IFNULL($progress, progress),

--- a/autoarena/service/task.py
+++ b/autoarena/service/task.py
@@ -110,10 +110,10 @@ class TaskService:
             conn.cursor().execute(
                 """
                 UPDATE task
-                SET progress = IFNULL($progress, progress),
-                    status = $status,
-                    logs = logs || '\n' || $log
-                WHERE id = $id
+                SET progress = IFNULL(:progress, progress),
+                    status = :status,
+                    logs = logs || '\n' || :log
+                WHERE id = :id
                 """,
                 dict(id=task_id, log=log, progress=progress, status=status.value),
             )

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -6,6 +6,8 @@ from typing import Iterator
 
 import pandas as pd
 
+from autoarena.store.utils import id_slug
+
 MIGRATION_DIRECTORY = Path(__file__).parent / "migration"
 
 DataDirectoryProvider: ContextVar[Path] = ContextVar("_DATA_DIRECTORY", default=Path.cwd() / "data")
@@ -16,6 +18,7 @@ def get_database_connection(path: Path, autocommit: bool = False) -> Iterator[sq
     conn = sqlite3.connect(str(path))
     try:
         # TODO: autocommit
+        conn.create_function("id_slug", 2, id_slug)
         conn.cursor().execute("PRAGMA foreign_keys = ON")  # TODO: is this necessary to run every time?
         yield conn
     finally:

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -7,7 +7,7 @@ from typing import Iterator
 
 import pandas as pd
 
-from autoarena.store.utils import id_slug
+from autoarena.store.utils import id_slug, invert_winner
 
 MIGRATION_DIRECTORY = Path(__file__).parent / "migration"
 
@@ -21,6 +21,7 @@ def get_database_connection(path: Path, commit: bool = False) -> Iterator[sqlite
     cur = conn.cursor()
     try:
         conn.create_function("id_slug", 2, id_slug)
+        conn.create_function("invert_winner", 1, invert_winner)
         cur.execute("PRAGMA foreign_keys = ON")
         yield conn
         if commit:

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -1,20 +1,20 @@
+import sqlite3
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+from typing import Iterator
 
-import duckdb
-
-DATABASE_FILE = Path.cwd() / "autoarena.duckdb"
 MIGRATION_DIRECTORY = Path(__file__).parent / "migration"
 
 DataDirectoryProvider: ContextVar[Path] = ContextVar("_DATA_DIRECTORY", default=Path.cwd() / "data")
 
 
 @contextmanager
-def get_database_connection(path: Path) -> duckdb.DuckDBPyConnection:
-    conn = duckdb.connect(str(path))
+def get_database_cursor(path: Path) -> Iterator[sqlite3.Cursor]:
+    conn = sqlite3.connect(str(path))
     try:
-        yield conn
+        # TODO: autocommit
+        yield conn.cursor()
     finally:
         conn.close()
 

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -10,12 +10,15 @@ DataDirectoryProvider: ContextVar[Path] = ContextVar("_DATA_DIRECTORY", default=
 
 
 @contextmanager
-def get_database_cursor(path: Path) -> Iterator[sqlite3.Cursor]:
+def get_database_connection(path: Path, autocommit: bool = False) -> Iterator[sqlite3.Connection]:
     conn = sqlite3.connect(str(path))
     try:
         # TODO: autocommit
-        yield conn.cursor()
+        conn.cursor().execute("PRAGMA foreign_keys = ON")  # TODO: is this necessary to run every time?
+        yield conn
     finally:
+        if autocommit:
+            conn.commit()
         conn.close()
 
 

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -18,9 +18,8 @@ DataDirectoryProvider: ContextVar[Path] = ContextVar("_DATA_DIRECTORY", default=
 def get_database_connection(path: Path, autocommit: bool = False) -> Iterator[sqlite3.Connection]:
     conn = sqlite3.connect(str(path))
     try:
-        # TODO: autocommit
         conn.create_function("id_slug", 2, id_slug)
-        conn.cursor().execute("PRAGMA foreign_keys = ON")  # TODO: is this necessary to run every time?
+        conn.cursor().execute("PRAGMA foreign_keys = ON")
         yield conn
     finally:
         if autocommit:

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -1,4 +1,5 @@
 import sqlite3
+import uuid
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -28,10 +29,11 @@ def get_database_connection(path: Path, autocommit: bool = False) -> Iterator[sq
 
 
 @contextmanager
-def temp_table(conn: sqlite3.Connection, df: pd.DataFrame, table_name: str) -> Iterator[None]:
+def temporary_table(conn: sqlite3.Connection, df: pd.DataFrame) -> Iterator[str]:
+    table_name = f"tmp_{uuid.uuid4()}".replace("-", "_")
     df.to_sql(table_name, conn, if_exists="fail", index=False)
     try:
-        yield
+        yield table_name
     finally:
         conn.execute(f"DROP TABLE {table_name}")
 

--- a/autoarena/store/migration/000__schema.sql
+++ b/autoarena/store/migration/000__schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS response (
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     prompt TEXT NOT NULL,
     response TEXT NOT NULL,
-    FOREIGN KEY (model_id) REFERENCES model (id),
+    FOREIGN KEY (model_id) REFERENCES model (id) ON DELETE CASCADE,
     -- TODO: should we allow dupes for nondeterminism? This is a convenience to skip duplicate inserts
     UNIQUE (model_id, prompt)
 );
@@ -40,9 +40,9 @@ CREATE TABLE IF NOT EXISTS head_to_head (
     judge_id INTEGER NOT NULL,
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     winner TEXT NOT NULL, -- e.g. "A", "B", "-"
-    FOREIGN KEY (response_a_id) REFERENCES response (id),
-    FOREIGN KEY (response_b_id) REFERENCES response (id),
-    FOREIGN KEY (judge_id) REFERENCES judge (id),
+    FOREIGN KEY (response_a_id) REFERENCES response (id) ON DELETE CASCADE,
+    FOREIGN KEY (response_b_id) REFERENCES response (id) ON DELETE CASCADE,
+    FOREIGN KEY (judge_id) REFERENCES judge (id) ON DELETE CASCADE,
     -- TODO: allow duplicate ratings from same judge (e.g. human)? Unique for now for convenience
     UNIQUE (response_id_slug, judge_id)
 );

--- a/autoarena/store/migration/000__schema.sql
+++ b/autoarena/store/migration/000__schema.sql
@@ -1,6 +1,5 @@
-CREATE SEQUENCE IF NOT EXISTS judge_id START 1;
 CREATE TABLE IF NOT EXISTS judge (
-    id INTEGER PRIMARY KEY DEFAULT nextval('judge_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     judge_type TEXT NOT NULL, -- enum e.g. 'human', 'ollama', 'openai'; see api.JudgeType
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     name TEXT NOT NULL UNIQUE,
@@ -10,9 +9,8 @@ CREATE TABLE IF NOT EXISTS judge (
     enabled BOOLEAN NOT NULL DEFAULT FALSE
 );
 
-CREATE SEQUENCE IF NOT EXISTS model_id START 1;
 CREATE TABLE IF NOT EXISTS model (
-    id INTEGER PRIMARY KEY DEFAULT nextval('model_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     name TEXT NOT NULL UNIQUE,
     elo DOUBLE PRECISION NOT NULL DEFAULT 1000,
@@ -20,9 +18,8 @@ CREATE TABLE IF NOT EXISTS model (
     q975 DOUBLE PRECISION
 );
 
-CREATE SEQUENCE IF NOT EXISTS response_id START 1;
 CREATE TABLE IF NOT EXISTS response (
-    id INTEGER PRIMARY KEY DEFAULT nextval('response_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     model_id INTEGER NOT NULL,
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     prompt TEXT NOT NULL,
@@ -35,12 +32,8 @@ CREATE TABLE IF NOT EXISTS response (
 -- TODO: would be great to use enum but it does not have an idempotent CREATE option
 -- CREATE TYPE WINNER AS ENUM ('A', 'B', '-');
 -- utility to create a deterministic slug from 2 numeric IDs presented in any order
-CREATE OR REPLACE MACRO id_slug(id_a, id_b) AS
-    IF(id_a < id_b, id_a, id_b)::INTEGER || '-' || IF(id_a < id_b, id_b, id_a)::INTEGER;
-CREATE OR REPLACE MACRO invert_winner(winner) AS IF(winner = 'A', 'B', IF(winner = 'B', 'A', winner));
-CREATE SEQUENCE IF NOT EXISTS head_to_head_id START 1;
 CREATE TABLE IF NOT EXISTS head_to_head (
-    id INTEGER PRIMARY KEY DEFAULT nextval('head_to_head_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     response_id_slug TEXT NOT NULL, -- see id_slug macro
     response_a_id INTEGER NOT NULL,
     response_b_id INTEGER NOT NULL,
@@ -54,9 +47,8 @@ CREATE TABLE IF NOT EXISTS head_to_head (
     UNIQUE (response_id_slug, judge_id)
 );
 
-CREATE SEQUENCE IF NOT EXISTS task_id START 1;
 CREATE TABLE IF NOT EXISTS task (
-    id INTEGER PRIMARY KEY DEFAULT nextval('task_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     task_type TEXT NOT NULL, -- enum e.g. 'auto-judge', 'recompute-leaderboard'; see api.TaskType
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     progress DOUBLE PRECISION NOT NULL DEFAULT 0, -- on [0,1]
@@ -64,9 +56,8 @@ CREATE TABLE IF NOT EXISTS task (
     logs TEXT NOT NULL DEFAULT '' -- freeform
 );
 
-CREATE SEQUENCE IF NOT EXISTS migration_id START 1;
 CREATE TABLE IF NOT EXISTS migration (
-    id INTEGER PRIMARY KEY DEFAULT nextval('migration_id'),
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     migration_index INTEGER NOT NULL UNIQUE,
     filename TEXT NOT NULL UNIQUE,
     created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp

--- a/autoarena/store/migration/000__schema.sql
+++ b/autoarena/store/migration/000__schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS response (
     -- TODO: should we allow dupes for nondeterminism? This is a convenience to skip duplicate inserts
     UNIQUE (model_id, prompt)
 );
+CREATE INDEX IF NOT EXISTS response_prompt_idx ON response (prompt);
 
 -- TODO: would be great to use enum but it does not have an idempotent CREATE option
 -- CREATE TYPE WINNER AS ENUM ('A', 'B', '-');

--- a/autoarena/store/utils.py
+++ b/autoarena/store/utils.py
@@ -5,6 +5,10 @@ def id_slug(a: int, b: int) -> str:
     return f"{int(min(a, b))}-{int(max(a, b))}"  # loaded as a sqlite extension
 
 
+def invert_winner(winner: str) -> str:
+    return "B" if winner == "A" else "A" if winner == "B" else winner
+
+
 def check_required_columns(df: pd.DataFrame, required_columns: list[str]) -> None:
     missing_columns = set(required_columns) - set(df.columns)
     if len(missing_columns) > 0:

--- a/autoarena/store/utils.py
+++ b/autoarena/store/utils.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 
 def id_slug(a: int, b: int) -> str:
-    return f"{int(min(a, b))}-{int(max(a, b))}"  # matches duckdb implementation in 000__schema.sql
+    return f"{int(min(a, b))}-{int(max(a, b))}"  # loaded as a sqlite extension
 
 
 def check_required_columns(df: pd.DataFrame, required_columns: list[str]) -> None:

--- a/autoarena/task/auto_judge.py
+++ b/autoarena/task/auto_judge.py
@@ -91,6 +91,7 @@ class AutoJudgeTask:
 
     def _retrieve_head_to_heads(self) -> pd.DataFrame:
         h2h_requests = [api.HeadToHeadsRequest(model_a_id=m.id) for m in self.models]
+        # TODO: calling this N times for N models is inefficient -- can take a few seconds on larger projects
         df_h2h = pd.concat([HeadToHeadService.get_df(self.project_slug, request) for request in h2h_requests])
         if len(df_h2h) == 0:
             self.log("No head-to-heads found, exiting", status=api.TaskStatus.COMPLETED, progress=1, level="WARNING")

--- a/autoarena/task/auto_judge.py
+++ b/autoarena/task/auto_judge.py
@@ -1,12 +1,11 @@
 import dataclasses
 import time
 from collections import defaultdict
-from typing import Optional, Callable
+from typing import Optional
 
 import pandas as pd
 from loguru import logger
 from pydantic.dataclasses import dataclass
-from tenacity import retry, stop_after_attempt, RetryCallState, wait_random_exponential
 
 from autoarena.api import api
 from autoarena.judge.base import AutomatedJudge
@@ -161,7 +160,7 @@ class AutoJudgeTask:
                 message = f"Judged {n_this_judge} of {n_h2h_by_judge_name[auto_judge.name]} with '{auto_judge.name}'"
                 self.log(message, progress=progress)
                 df_h2h_chunk = pd.DataFrame(responses[auto_judge.name][-self.update_every :], columns=out_columns)
-                self._try_write(lambda: HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_chunk))
+                HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_chunk)
             if n_this_judge == n_h2h_by_judge_name[auto_judge.name]:
                 message = (
                     f"Judge '{auto_judge.name}' finished judging {n_h2h_by_judge_name[auto_judge.name]} head-to-heads "
@@ -171,28 +170,9 @@ class AutoJudgeTask:
                 for usage_summary_line in auto_judge.get_usage_summary():
                     self.log(usage_summary_line)
                 df_h2h_all = pd.DataFrame(responses[auto_judge.name], columns=out_columns)
-                self._try_write(lambda: HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_all))
+                HeadToHeadService.upload_head_to_heads(self.project_slug, df_h2h_all)
 
         self.log("Recomputing leaderboard rankings", progress=0.975)
-        self._try_write(lambda: EloService.reseed_scores(self.project_slug, config=self.elo_config))
+        EloService.reseed_scores(self.project_slug, config=self.elo_config)
         message = f"Completed automated judging in {time.time() - self.t_start:0.1f} seconds"
         self.log(message, progress=1, status=api.TaskStatus.COMPLETED, level="SUCCESS")
-
-    @staticmethod
-    def _try_write(write_thunk: Callable[[], None]) -> None:
-        """
-        We're running into a limitation of DuckDB here -- concurrent writes are not well-supported. Give a best effort
-        by retrying write attempts, an [officially endorsed strategy](https://duckdb.org/docs/connect/concurrency.html).
-
-        This situation could be improved but requires answering tough questions about what kind of operations we want to
-        optimize the persistence layer for, and what kind of operations we're OK with it struggling with.
-        """
-
-        def _log_retry(retry_state: RetryCallState) -> None:
-            logger.warning(f"Retrying write attempt {retry_state.attempt_number} (error: {retry_state.outcome})")
-
-        @retry(wait=wait_random_exponential(max=5), stop=stop_after_attempt(5), after=_log_retry)
-        def _try_write_inner(thunk: Callable[[], None]) -> None:
-            thunk()
-
-        return _try_write_inner(write_thunk)

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 AutoArena uses the `./data` directory to store files for each project.
 
-For example, creating a new project `example` via the UI creates a file in this directory named `example.duckdb`
+For example, creating a new project `example` via the UI creates a file in this directory named `example.sqlite`
 containing the models, judges, head-to-heads, and other data associated with the `example` project.
 
 Project files are portable and can be "loaded" onto another machine by copying them over to a `./data` directory located

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "fastapi<1",
     "pandas>=2,<3",
     "uvicorn<1",
-    "duckdb",
     "pyarrow",
     "python-multipart",
     "loguru<1",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,7 +50,7 @@ def api_v1_client(test_data_directory: Path) -> Iterator[TestClient]:
 @pytest.fixture(scope="function")
 def project_slug(api_v1_client: TestClient, test_data_directory: Path) -> Iterator[str]:
     slug = f"test-{str(uuid.uuid4())}"
-    database_file = test_data_directory / f"{slug}.duckdb"
+    database_file = test_data_directory / f"{slug}.sqlite"
     database_file.unlink(missing_ok=True)
     api_v1_client.put("/project", json=dict(name=slug)).json()
     try:

--- a/tests/integration/service/test_projects.py
+++ b/tests/integration/service/test_projects.py
@@ -65,7 +65,8 @@ def test__migration__existing__pre_migration_system(test_data_directory: Path) -
     with sqlite3.connect(str(old_database_file)) as conn:
         cur = conn.cursor()
         # manually construct a database in the state that it would be in before introducing this migration system
-        cur.execute(initial_migration_file.read_text())
+        cur.executescript(initial_migration_file.read_text())
         cur.execute("DROP TABLE migration")
+        conn.commit()
     project = ProjectService.create_idempotent(api.CreateProjectRequest(name=project_name))
     assert_all_migrations_applied(project)

--- a/tests/integration/service/test_projects.py
+++ b/tests/integration/service/test_projects.py
@@ -1,6 +1,6 @@
+import sqlite3
 from pathlib import Path
 
-import duckdb
 import pytest
 
 from autoarena.api import api
@@ -60,11 +60,12 @@ def test__migration__existing(test_data_directory: Path) -> None:
 
 def test__migration__existing__pre_migration_system(test_data_directory: Path) -> None:
     project_name = "test__migration__existing__pre_migration_system"
-    old_database_file = test_data_directory / f"{project_name}.duckdb"
+    old_database_file = test_data_directory / f"{project_name}.sqlite"
     initial_migration_file = get_available_migrations()[0]
-    with duckdb.connect(str(old_database_file)) as conn:
+    with sqlite3.connect(str(old_database_file)) as conn:
+        cur = conn.cursor()
         # manually construct a database in the state that it would be in before introducing this migration system
-        conn.sql(initial_migration_file.read_text())
-        conn.execute("DROP TABLE migration")
+        cur.execute(initial_migration_file.read_text())
+        cur.execute("DROP TABLE migration")
     project = ProjectService.create_idempotent(api.CreateProjectRequest(name=project_name))
     assert_all_migrations_applied(project)

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Group, Kbd, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
+import { Box, Button, Group, Kbd, Paper, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import {
   IconArrowDown,
   IconArrowLeft,
@@ -87,7 +87,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
   const modelNames = modelA != null && modelB != null ? `'${modelA.name}' and '${modelB.name}'` : 'selected models';
   const iconProps = { size: 18 };
   return (
-    <Stack pb={height + 32}>
+    <Stack pb={Math.max(height, 100) + 32}>
       <Group justify="space-between">
         <Paper withBorder>
           <Button.Group>
@@ -168,7 +168,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
 
           <ControlBar ref={controlBarRef}>
             <Stack align="center" gap="xs">
-              <Text fw="bold">Which response is better?</Text>
+              <Title order={5}>Which response is better?</Title>
               <SimpleGrid cols={5} spacing="xs">
                 <Button
                   leftSection={<Kbd>b</Kbd>}


### PR DESCRIPTION
DuckDB, while offering a great devx, is not the right choice for a database (project file) with many concurrent writes (e.g. when running automated judgement and using the web UI). Transactions have some [undesirable behaviors](https://github.com/duckdb/duckdb/issues/13819) and concurrency is [not well supported](https://duckdb.org/docs/connect/concurrency.html#optimistic-concurrency-control). As such, this PR migrates to use SQLite, which offers comparable performance with a much better concurrency+atomicity story. 

Other improvements:
- Reduced dependencies: `sqlite` is part of the standard library
- Pandas implements `pd.read_sql_query` as a ~drop-in replacement for `conn.sql(...).df()` from DuckDB
- Cascading deletes are supported via the `foreign_keys` pragma, simplifying cleanup logic

Note that **⚠️ no effort is made to migrate existing DuckDB projects to SQLite. ⚠️** This is part of AutoArena being in early beta releases; it's important to get these breaking changes out of the way before the first production release coming soon.