### PR TITLE
Off-happy-path usability improvements

### DIFF
--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -89,6 +89,9 @@ class ModelService:
             check_required_columns(df_response, ["prompt", "response"])
         except ValueError as e:
             raise BadRequestError(str(e))
+        n_duplicate_prompts = len(df_response) - len(set(df_response["prompt"]))
+        if n_duplicate_prompts > 0:
+            raise BadRequestError(f"Each 'prompt' value must be unique (received {n_duplicate_prompts} duplicate(s))")
         n_input = len(df_response)
         df_response = df_response.copy().dropna(subset=["prompt", "response"])
         if len(df_response) != n_input:

--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -89,6 +89,8 @@ class ModelService:
             check_required_columns(df_response, ["prompt", "response"])
         except ValueError as e:
             raise BadRequestError(str(e))
+        if len(df_response) == 0:
+            raise BadRequestError("Responses must not be empty")
         n_duplicate_prompts = len(df_response) - len(set(df_response["prompt"]))
         if n_duplicate_prompts > 0:
             raise BadRequestError(f"Each 'prompt' value must be unique (received {n_duplicate_prompts} duplicate(s))")

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -60,6 +60,14 @@ def test__models__upload__missing_values(project_client: TestClient, df: pd.Data
     assert models[0]["n_responses"] == len(df) - n_dropped
 
 
+def test__models__upload__duplicate_prompts(project_client: TestClient) -> None:
+    df = pd.DataFrame([("p", "r1"), ("p", "r2")], columns=["prompt", "response"])
+    body = construct_upload_model_body(dict(example=df))
+    response = project_client.post("/model", data=body.data, files=body.files)
+    assert response.status_code == 400
+    assert "Each 'prompt' value must be unique" in response.json()["detail"]
+
+
 def test__models__upload__multiple(project_client: TestClient) -> None:
     body = construct_upload_model_body(dict(a=DF_RESPONSE, b=DF_RESPONSE_B))
     models = project_client.post("/model", data=body.data, files=body.files).json()

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -29,6 +29,13 @@ def test__models__upload(project_client: TestClient, model_id: int) -> None:
     assert models[0]["n_votes"] == 0
 
 
+def test__models__upload__empty(project_client: TestClient) -> None:
+    body = construct_upload_model_body(dict(bad=pd.DataFrame([], columns=["prompt", "response"])))
+    response = project_client.post("/model", data=body.data, files=body.files)
+    assert response.status_code == 400
+    assert "Responses must not be empty"
+
+
 @pytest.mark.parametrize(
     "df_bad,missing",
     [
@@ -37,7 +44,7 @@ def test__models__upload(project_client: TestClient, model_id: int) -> None:
         (pd.DataFrame.from_records([dict(bad="yes", prompt="what")]), {"response"}),
     ],
 )
-def test__models__upload__failed(project_client: TestClient, df_bad: pd.DataFrame, missing: set[str]) -> None:
+def test__models__upload__missing_columns(project_client: TestClient, df_bad: pd.DataFrame, missing: set[str]) -> None:
     body = construct_upload_model_body(dict(bad=df_bad))
     response = project_client.post("/model", data=body.data, files=body.files)
     assert response.status_code == 400

--- a/ui/src/components/AddModelButton.tsx
+++ b/ui/src/components/AddModelButton.tsx
@@ -15,7 +15,8 @@ import {
 import { IconCheck, IconPlus, IconX } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import { useMemo, useState } from 'react';
-import { useUploadModelResponses, useUrlState, useModels, useJudges } from '../hooks';
+import { Link } from 'react-router-dom';
+import { useUploadModelResponses, useUrlState, useModels, useJudges, useAppRoutes } from '../hooks';
 import { pluralize } from '../lib';
 import { ConfirmOrCancelBar, isEnabledAutoJudge } from './Judges';
 
@@ -25,10 +26,11 @@ type Props = {
 };
 export function AddModelButton({ variant, size }: Props) {
   const { projectSlug = '' } = useUrlState();
+  const { appRoutes } = useAppRoutes();
   const { data: models } = useModels(projectSlug);
   const { data: judges } = useJudges(projectSlug);
-  const [isOpen, { toggle, close }] = useDisclosure(false);
   const { mutate: uploadModelResponses } = useUploadModelResponses({ projectSlug });
+  const [isOpen, { toggle, close }] = useDisclosure(false);
 
   const [files, setFiles] = useState<File[]>([]);
   const [names, setNames] = useState<string[]>([]);
@@ -130,9 +132,19 @@ export function AddModelButton({ variant, size }: Props) {
                     : 'No automated judges configured'}
                 </Text>
                 <Text inherit c="dimmed">
-                  {configuredAutoJudges.length > 0
-                    ? `Model${files.length > 0 ? 's' : ''} will be ranked against existing models on leaderboard`
-                    : 'Configure an automated judge to rank against existing models'}
+                  {configuredAutoJudges.length > 0 ? (
+                    `Model${files.length > 0 ? 's' : ''} will be ranked against existing models on leaderboard`
+                  ) : (
+                    <>
+                      <Link
+                        to={appRoutes.judges(projectSlug)}
+                        style={{ textDecoration: 'none', color: 'var(--mantine-color-kolena-light-color)' }}
+                      >
+                        Configure an automated judge
+                      </Link>{' '}
+                      to rank against existing models
+                    </>
+                  )}
                 </Text>
               </Stack>
             </Text>

--- a/ui/src/components/HeadToHead/HeadToHead.tsx
+++ b/ui/src/components/HeadToHead/HeadToHead.tsx
@@ -5,9 +5,9 @@ import { IconClick } from '@tabler/icons-react';
 import { prop, sortBy } from 'ramda';
 import { useUrlState, useModels } from '../../hooks';
 import { NonIdealState } from '../NonIdealState.tsx';
+import { APP_CONTENT_WIDTH } from '../constants.ts';
 import { HeadToHeadTwoModels } from './HeadToHeadTwoModels.tsx';
 import { HeadToHeadSingleModel } from './HeadToHeadSingleModel.tsx';
-import {APP_CONTENT_WIDTH} from "../constants.ts";
 
 export function HeadToHead() {
   const { projectSlug } = useUrlState();

--- a/ui/src/components/HeadToHead/HeadToHead.tsx
+++ b/ui/src/components/HeadToHead/HeadToHead.tsx
@@ -7,6 +7,7 @@ import { useUrlState, useModels } from '../../hooks';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { HeadToHeadTwoModels } from './HeadToHeadTwoModels.tsx';
 import { HeadToHeadSingleModel } from './HeadToHeadSingleModel.tsx';
+import {APP_CONTENT_WIDTH} from "../constants.ts";
 
 export function HeadToHead() {
   const { projectSlug } = useUrlState();
@@ -60,7 +61,7 @@ export function HeadToHead() {
   const noMoreModels = allSelectModels.length - (modelA != null ? 1 : 0) - (modelB != null ? 1 : 0) < 1;
   return (
     <Center p="lg">
-      <Stack w={1080} /* TODO: should be max width */>
+      <Stack w={APP_CONTENT_WIDTH}>
         <Group justify="space-between" grow>
           <Group align="flex-end" justify="space-between">
             <Select

--- a/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
+++ b/ui/src/components/Judges/CreateFineTunedJudgeModal.tsx
@@ -48,10 +48,11 @@ export function CreateFineTunedJudgeModal({ isOpen, onClose }: Props) {
         <Text size="sm">
           Start a <b>fine-tuning job</b> to create a custom judge model using the {pluralize(nVotes, 'manual vote')}{' '}
           submitted on the{' '}
-          <Link to={appRoutes.compare(projectSlug)} style={{ textDecoration: 'none' }}>
-            <Text span c="kolena">
-              Head-to-Head
-            </Text>
+          <Link
+            to={appRoutes.compare(projectSlug)}
+            style={{ textDecoration: 'none', color: 'var(--mantine-color-kolena-light-color)' }}
+          >
+            Head-to-Head
           </Link>{' '}
           tab within the <Code>{project?.slug}</Code> project.
         </Text>

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -136,10 +136,11 @@ export function JudgeAccordionItem({ judge }: Props) {
             <Group justify="space-between">
               <Text size="sm">
                 Visit the{' '}
-                <Link to={appRoutes.compare(projectSlug)} style={{ textDecoration: 'none' }}>
-                  <Text span c="kolena.8">
-                    Head-to-Head
-                  </Text>
+                <Link
+                  to={appRoutes.compare(projectSlug)}
+                  style={{ textDecoration: 'none', color: 'var(--mantine-color-kolena-light-color)' }}
+                >
+                  Head-to-Head
                 </Link>{' '}
                 tab to provide ratings on head-to-head matchups between models.
               </Text>

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { ReactNode } from 'react';
 import { useJudges, useUrlState } from '../../hooks';
 import { ExternalUrls, useAppConfig } from '../../lib';
+import { APP_CONTENT_WIDTH } from '../constants.ts';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
 import { CreateJudgeModal } from './CreateJudgeModal.tsx';
 import { CreateFineTunedJudgeModal } from './CreateFineTunedJudgeModal.tsx';
@@ -29,9 +30,9 @@ export function Judges() {
 
   return (
     <Center p="lg">
-      <Stack>
+      <Stack w={APP_CONTENT_WIDTH}>
         <Title order={5}>Configured Judges</Title>
-        <Accordion variant="contained" w={1080}>
+        <Accordion variant="contained">
           {(judges ?? []).map(judge => (
             <JudgeAccordionItem key={judge.id} judge={judge} />
           ))}
@@ -40,7 +41,7 @@ export function Judges() {
         <Divider />
 
         <Title order={5}>Configure Automated Judge</Title>
-        <SimpleGrid cols={3} w={1080}>
+        <SimpleGrid cols={3}>
           {enabledJudges.map((judgeType, i) => {
             const CardComponent = availableJudges[judgeType];
             return <CardComponent key={i} />;

--- a/ui/src/components/Leaderboard/Leaderboard.tsx
+++ b/ui/src/components/Leaderboard/Leaderboard.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
-import { Group, Loader, Paper, Stack, TextInput } from '@mantine/core';
+import { Center, Group, Loader, Paper, Stack, TextInput } from '@mantine/core';
 import { DataTable, DataTableSortStatus } from 'mantine-datatable';
 import { prop, sortBy } from 'ramda';
 import { useModels, useUrlState, useOnboardingGuideDismissed, useModelsRankedByJudge } from '../../hooks';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { AddModelButton } from '../AddModelButton.tsx';
 import { OnboardingTimeline } from '../OnboardingTimeline.tsx';
+import { APP_CONTENT_WIDTH } from '../constants.ts';
 import { RankedModel } from './types.ts';
 import { LEADERBOARD_COLUMNS, LOADING_MODELS } from './columns.tsx';
 import { ExpandedModelDetails } from './ExpandedModelDetails.tsx';
@@ -53,53 +54,55 @@ export function Leaderboard() {
   );
 
   return onboardingGuideDismissed || isLoadingModels || allModels.length > 0 ? (
-    <Stack p="lg" align="center">
-      <Group justify="space-between" w={1080} align="flex-end">
-        <TextInput
-          label="Filter Models"
-          placeholder="Enter filter value..."
-          value={filterValue}
-          onChange={event => setFilterValue(event.currentTarget.value)}
-          flex={1}
-          disabled={isLoadingModels}
-        />
-        <LeaderboardJudgeSelect />
-        <LeaderboardSettings />
-        <AddModelButton variant="light" />
-      </Group>
+    <Center p="lg">
+      <Stack align="center" w={APP_CONTENT_WIDTH}>
+        <Group justify="space-between" align="flex-end" w="100%">
+          <TextInput
+            label="Filter Models"
+            placeholder="Enter filter value..."
+            value={filterValue}
+            onChange={event => setFilterValue(event.currentTarget.value)}
+            flex={1}
+            disabled={isLoadingModels}
+          />
+          <LeaderboardJudgeSelect />
+          <LeaderboardSettings />
+          <AddModelButton variant="light" />
+        </Group>
 
-      <Paper radius="md" pos="relative" withBorder w={1080}>
-        <DataTable<RankedModel>
-          striped
-          withTableBorder={false}
-          borderRadius="md"
-          horizontalSpacing="xs"
-          minHeight={modelRecords.length === 0 ? 180 : undefined}
-          columns={LEADERBOARD_COLUMNS}
-          highlightOnHover
-          records={modelRecords}
-          idAccessor="id"
-          rowExpansion={{
-            content: ({ record }) => <ExpandedModelDetails model={record} />,
-            // NOTE: default smooth transition can be choppy with more than ~20 models, turn it off
-            collapseProps: { transitionDuration: 0 },
-          }}
-          sortStatus={sortStatus}
-          onSortStatusChange={setSortStatus}
-          fetching={isLoadingModels || isLoadingModelsRankedByJudge}
-          loaderBackgroundBlur={4}
-          customLoader={<NonIdealState icon={<Loader />} description="Crunching leaderboard rankings..." />}
-          selectedRecords={selectedRecords}
-          onSelectedRecordsChange={setSelectedRecords}
-          isRecordSelectable={({ id }) => selectedRecords.length < 2 || selectedIds.has(id)}
-          allRecordsSelectionCheckboxProps={{ display: 'none' }}
-        />
+        <Paper radius="md" pos="relative" withBorder w="100%">
+          <DataTable<RankedModel>
+            striped
+            withTableBorder={false}
+            borderRadius="md"
+            horizontalSpacing="xs"
+            minHeight={modelRecords.length === 0 ? 180 : undefined}
+            columns={LEADERBOARD_COLUMNS}
+            highlightOnHover
+            records={modelRecords}
+            idAccessor="id"
+            rowExpansion={{
+              content: ({ record }) => <ExpandedModelDetails model={record} />,
+              // NOTE: default smooth transition can be choppy with more than ~20 models, turn it off
+              collapseProps: { transitionDuration: 0 },
+            }}
+            sortStatus={sortStatus}
+            onSortStatusChange={setSortStatus}
+            fetching={isLoadingModels || isLoadingModelsRankedByJudge}
+            loaderBackgroundBlur={4}
+            customLoader={<NonIdealState icon={<Loader />} description="Crunching leaderboard rankings..." />}
+            selectedRecords={selectedRecords}
+            onSelectedRecordsChange={setSelectedRecords}
+            isRecordSelectable={({ id }) => selectedRecords.length < 2 || selectedIds.has(id)}
+            allRecordsSelectionCheckboxProps={{ display: 'none' }}
+          />
 
-        {selectedRecords.length > 0 && <ExploreSelectedModels selectedModels={selectedRecords} />}
-      </Paper>
+          {selectedRecords.length > 0 && <ExploreSelectedModels selectedModels={selectedRecords} />}
+        </Paper>
 
-      <OnboardingTimeline />
-    </Stack>
+        <OnboardingTimeline />
+      </Stack>
+    </Center>
   ) : (
     <Stack p="lg" align="center" justify="center" h="calc(100vh - 58px)">
       <OnboardingTimeline />

--- a/ui/src/components/Page.tsx
+++ b/ui/src/components/Page.tsx
@@ -12,6 +12,7 @@ import { TasksDrawer } from './TasksDrawer';
 import { OnboardingTimeline } from './OnboardingTimeline.tsx';
 import { MainMenu } from './MainMenu.tsx';
 import { Tab } from './types.ts';
+import { APP_CONTENT_WIDTH } from './constants.ts';
 
 type Props = {
   tab: Tab;
@@ -53,7 +54,7 @@ export function Page({ tab }: Props) {
 
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
   return (
-    <Tabs value={tab} onChange={setTab} keepMounted={false}>
+    <Tabs value={tab} onChange={setTab} keepMounted={false} style={{ minWidth: APP_CONTENT_WIDTH }}>
       <Tabs.List bg="gray.0" style={{ position: 'sticky', top: 0, zIndex: 10 }}>
         <Group align="center" p="xs" pl="lg" pr="xl" h={58}>
           <MainMenu />

--- a/ui/src/components/constants.ts
+++ b/ui/src/components/constants.ts
@@ -1,0 +1,2 @@
+// TODO: eventually all pages should be responsive; for now, target 1080px content width within app
+export const APP_CONTENT_WIDTH = 1080;

--- a/ui/src/hooks/useUploadModelResponses.ts
+++ b/ui/src/hooks/useUploadModelResponses.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 import { notifications } from '@mantine/notifications';
 import { zip } from 'ramda';
-import { urlAsQueryKey, useAppConfig } from '../lib';
+import { pluralize, urlAsQueryKey, useAppConfig } from '../lib';
 import { Model } from './useModels.ts';
 import { useAppRoutes } from './useAppRoutes.ts';
 
@@ -39,6 +39,14 @@ export function useUploadModelResponses({ projectSlug, options }: Params) {
       const result: Model[] = await response.json();
       return result;
     },
+    onMutate: ([, modelNames]) => {
+      notifications.show({
+        message: `Uploading responses from ${pluralize(modelNames.length, 'model')}...`,
+        loading: true,
+        autoClose: false,
+        id: 'uploading-model-responses',
+      });
+    },
     onError: e => {
       notifications.show({
         title: 'Failed to add model responses',
@@ -60,6 +68,7 @@ export function useUploadModelResponses({ projectSlug, options }: Params) {
       notifications.show({ title, message, color: 'green' });
     },
     onSettled: () => {
+      notifications.hide('uploading-model-responses');
       queryClient.invalidateQueries({ queryKey: urlAsQueryKey(apiRoutes.getModels(projectSlug)) });
       queryClient.invalidateQueries({ queryKey: urlAsQueryKey(apiRoutes.getTasks(projectSlug)) });
     },

--- a/ui/src/hooks/useUploadModelResponses.ts
+++ b/ui/src/hooks/useUploadModelResponses.ts
@@ -27,16 +27,24 @@ export function useUploadModelResponses({ projectSlug, options }: Params) {
       });
       const response = await apiFetch(url, { method: 'POST', body: formData });
       if (!response.ok) {
-        throw new Error('Failed to add model responses');
+        let detail: string;
+        try {
+          const error: { detail: string } = await response.json();
+          detail = error.detail;
+        } catch (e) {
+          detail = 'Unable to add model responses';
+        }
+        throw new Error(detail);
       }
       const result: Model[] = await response.json();
       return result;
     },
-    onError: () => {
+    onError: e => {
       notifications.show({
         title: 'Failed to add model responses',
-        message: 'Unable to add model responses',
+        message: e.toString(),
         color: 'red',
+        autoClose: 10_000,
       });
     },
     onSuccess: (models: Model[]) => {


### PR DESCRIPTION
- Link to judges tab from add model responses modal when no judges are configured
- Display error information to users when response uploads fail
- Set app-wide min-width to preserve usability on thin viewports (as a stopgap for true responsiveness)
- Add loading spinner while model response uploads are processing