### PR TITLE
Add system to override UI props via AppConfig

### DIFF
--- a/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
+++ b/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
@@ -7,10 +7,10 @@ import { JudgeType, judgeTypeToApiKeyName, judgeTypeToHumanReadableName } from '
 
 type Props = {
   judgeType: JudgeType;
-  CallToActionComponent?: ReactNode;
+  CallToActionComponent?: ({ judgeType }: JudgeType) => ReactNode;
 };
 export function CanAccessJudgeStatusIndicator(props: Props) {
-  const { judgeType, CallToActionComponent: MaybeCTA } = usePropOverrides(CanAccessJudgeStatusIndicator, props);
+  const { judgeType, CallToActionComponent } = usePropOverrides(CanAccessJudgeStatusIndicator, props);
   const { projectSlug = '' } = useUrlState();
   const { data: canAccess, isLoading } = useCanAccessJudgeType({ projectSlug, judgeType });
   const judgeTypeName = judgeTypeToHumanReadableName(judgeType);
@@ -44,21 +44,22 @@ export function CanAccessJudgeStatusIndicator(props: Props) {
       ) : (
         <Stack gap={4}>
           <Text size="sm">Unable to access {judgeTypeName} API</Text>
-          {MaybeCTA ??
-            (apiKeyName != null ? (
-              <Text size="xs" c="dimmed">
-                Ensure that you have the <Code>{apiKeyName}</Code> variable set in the environment running AutoArena.
-              </Text>
-            ) : judgeType === 'unrecognized' ? (
-              <Text size="xs" c="dimmed">
-                This judge has an unrecognized type. Ensure that you are running the latest version of AutoArena.
-              </Text>
-            ) : (
-              <Text size="xs" c="dimmed">
-                Ensure that you have the relevant configuration for the {judgeTypeName} API in the environment running
-                AutoArena.
-              </Text>
-            ))}
+          {CallToActionComponent != null ? (
+            <CallToActionComponent judgeType={judgeType} />
+          ) : apiKeyName != null ? (
+            <Text size="xs" c="dimmed">
+              Ensure that you have the <Code>{apiKeyName}</Code> variable set in the environment running AutoArena.
+            </Text>
+          ) : judgeType === 'unrecognized' ? (
+            <Text size="xs" c="dimmed">
+              This judge has an unrecognized type. Ensure that you are running the latest version of AutoArena.
+            </Text>
+          ) : (
+            <Text size="xs" c="dimmed">
+              Ensure that you have the relevant configuration for the {judgeTypeName} API in the environment running
+              AutoArena.
+            </Text>
+          )}
         </Stack>
       )}
     </Group>

--- a/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
+++ b/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
@@ -1,12 +1,16 @@
 import { Code, Group, Loader, Stack, Text } from '@mantine/core';
 import { IconCheck, IconX } from '@tabler/icons-react';
+import { ReactNode } from 'react';
 import { useCanAccessJudgeType, useUrlState } from '../../hooks';
+import { usePropOverrides } from '../../lib';
 import { JudgeType, judgeTypeToApiKeyName, judgeTypeToHumanReadableName } from './types.ts';
 
 type Props = {
   judgeType: JudgeType;
+  CallToActionComponent?: ReactNode;
 };
-export function CanAccessJudgeStatusIndicator({ judgeType }: Props) {
+export function CanAccessJudgeStatusIndicator(props: Props) {
+  const { judgeType, CallToActionComponent: MaybeCTA } = usePropOverrides(CanAccessJudgeStatusIndicator, props);
   const { projectSlug = '' } = useUrlState();
   const { data: canAccess, isLoading } = useCanAccessJudgeType({ projectSlug, judgeType });
   const judgeTypeName = judgeTypeToHumanReadableName(judgeType);
@@ -40,20 +44,21 @@ export function CanAccessJudgeStatusIndicator({ judgeType }: Props) {
       ) : (
         <Stack gap={4}>
           <Text size="sm">Unable to access {judgeTypeName} API</Text>
-          {apiKeyName != null ? (
-            <Text size="xs" c="dimmed">
-              Ensure that you have the <Code>{apiKeyName}</Code> variable set in the environment running AutoArena.
-            </Text>
-          ) : judgeType === 'unrecognized' ? (
-            <Text size="xs" c="dimmed">
-              This judge has an unrecognized type. Ensure that you are running the latest version of AutoArena.
-            </Text>
-          ) : (
-            <Text size="xs" c="dimmed">
-              Ensure that you have the relevant configuration for the {judgeTypeName} API in the environment running
-              AutoArena.
-            </Text>
-          )}
+          {MaybeCTA ??
+            (apiKeyName != null ? (
+              <Text size="xs" c="dimmed">
+                Ensure that you have the <Code>{apiKeyName}</Code> variable set in the environment running AutoArena.
+              </Text>
+            ) : judgeType === 'unrecognized' ? (
+              <Text size="xs" c="dimmed">
+                This judge has an unrecognized type. Ensure that you are running the latest version of AutoArena.
+              </Text>
+            ) : (
+              <Text size="xs" c="dimmed">
+                Ensure that you have the relevant configuration for the {judgeTypeName} API in the environment running
+                AutoArena.
+              </Text>
+            ))}
         </Stack>
       )}
     </Group>

--- a/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
+++ b/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
@@ -7,7 +7,7 @@ import { JudgeType, judgeTypeToApiKeyName, judgeTypeToHumanReadableName } from '
 
 type Props = {
   judgeType: JudgeType;
-  CallToActionComponent?: ({ judgeType }: JudgeType) => ReactNode;
+  CallToActionComponent?: ({ judgeType }: { judgeType: JudgeType }) => ReactNode;
 };
 export function CanAccessJudgeStatusIndicator(props: Props) {
   const { judgeType, CallToActionComponent } = usePropOverrides(CanAccessJudgeStatusIndicator, props);

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -2,7 +2,7 @@ import { Accordion, Anchor, Center, Divider, SimpleGrid, Stack, Title, Text, Cod
 import { useDisclosure } from '@mantine/hooks';
 import { ReactNode } from 'react';
 import { useJudges, useUrlState } from '../../hooks';
-import { ExternalUrls, useAppConfig } from '../../lib';
+import { ExternalUrls, usePropOverrides } from '../../lib';
 import { APP_CONTENT_WIDTH } from '../constants.ts';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
 import { CreateJudgeModal } from './CreateJudgeModal.tsx';
@@ -10,10 +10,13 @@ import { CreateFineTunedJudgeModal } from './CreateFineTunedJudgeModal.tsx';
 import { JudgeAccordionItem } from './JudgeAccordionItem.tsx';
 import { JudgeType } from './types.ts';
 
-export function Judges() {
+type Props = {
+  enabledJudges: JudgeType[];
+};
+export function Judges(props: Props) {
+  const { enabledJudges } = usePropOverrides(Judges, props);
   const { projectSlug } = useUrlState();
   const { data: judges } = useJudges(projectSlug);
-  const { enabledJudges } = useAppConfig();
 
   const availableJudges: { [judgeType in JudgeType]: () => ReactNode } = {
     custom: CreateFineTunedJudgeCard,

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -1,11 +1,15 @@
 import { Anchor, Group, Menu, Title, Tooltip, UnstyledButton } from '@mantine/core';
 import { IconBeta, IconBrandGithub, IconBrandSlack, IconBug, IconHome, IconStack2Filled } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
-import { ExternalUrls, useAppConfig } from '../lib';
+import { ReactNode } from 'react';
+import { ExternalUrls, usePropOverrides } from '../lib';
 import { useAppRoutes } from '../hooks';
 
-export function MainMenu() {
-  const { menuExtras } = useAppConfig();
+type Props = {
+  extraMenuItems?: ReactNode[];
+};
+export function MainMenu(props: Props) {
+  const { extraMenuItems } = usePropOverrides(MainMenu, props);
   const { appRoutes } = useAppRoutes();
 
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };
@@ -38,7 +42,7 @@ export function MainMenu() {
         <Anchor href={ExternalUrls.AUTOARENA_SLACK_COMMUNITY} underline="never" target="_blank">
           <Menu.Item leftSection={<IconBrandSlack {...iconProps} />}>Slack Community</Menu.Item>
         </Anchor>
-        {menuExtras}
+        {extraMenuItems}
       </Menu.Dropdown>
     </Menu>
   );

--- a/ui/src/components/Page.tsx
+++ b/ui/src/components/Page.tsx
@@ -92,7 +92,7 @@ export function Page({ tab }: Props) {
         <HeadToHead />
       </Tabs.Panel>
       <Tabs.Panel value={Tab.JUDGES}>
-        <Judges />
+        <Judges enabledJudges={['openai', 'anthropic', 'cohere', 'ollama', 'gemini', 'together', 'bedrock']} />
       </Tabs.Panel>
     </Tabs>
   );

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,8 +1,8 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
 import { Context, createContext, useContext } from 'react';
 
-type PropOverrideKey = React.JSXElementConstructor<never>;
-type PropOverrideValue = { [key: string]: unknown };
+export type PropOverrideKey = React.JSXElementConstructor<never>;
+export type PropOverrideValue = { [key: string]: unknown };
 
 export type AppConfig = {
   baseApiUrl: string;

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,9 +1,8 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
 import { Context, createContext, useContext } from 'react';
-import { Judges, MainMenu } from '../components';
 
-type PropOverrideKey = React.JSXElementConstructor<any>;
-type PropOverrideValue = { [key: string]: any };
+type PropOverrideKey = React.JSXElementConstructor<never>;
+type PropOverrideValue = { [key: string]: unknown };
 
 export type AppConfig = {
   baseApiUrl: string;
@@ -18,10 +17,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   basePath: '',
   apiFetch: fetch,
   apiFetchEventSource: fetchEventSource,
-  propOverrides: new Map([
-    [MainMenu, { extraMenuItems: ['foobar'] }],
-    [Judges, { enabledJudges: ['openai'] }],
-  ] as [PropOverrideKey, PropOverrideValue][]),
+  propOverrides: new Map(),
 };
 
 export const AppConfigContext: Context<AppConfig> = createContext(DEFAULT_APP_CONFIG);

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,14 +1,16 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
-import { Context, createContext, ReactNode, useContext } from 'react';
-import { JudgeType } from '../components';
+import { Context, createContext, useContext } from 'react';
+import { Judges, MainMenu } from '../components';
+
+type PropOverrideKey = React.JSXElementConstructor<any>;
+type PropOverrideValue = { [key: string]: any };
 
 export type AppConfig = {
   baseApiUrl: string;
   basePath: string;
   apiFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   apiFetchEventSource: (input: RequestInfo, init: FetchEventSourceInit) => Promise<void>;
-  enabledJudges: JudgeType[];
-  menuExtras: ReactNode[];
+  propOverrides: Map<PropOverrideKey, PropOverrideValue>;
 };
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
@@ -16,12 +18,20 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   basePath: '',
   apiFetch: fetch,
   apiFetchEventSource: fetchEventSource,
-  enabledJudges: ['openai', 'anthropic', 'cohere', 'ollama', 'gemini', 'together', 'bedrock'],
-  menuExtras: [],
+  propOverrides: new Map([
+    [MainMenu, { extraMenuItems: ['foobar'] }],
+    [Judges, { enabledJudges: ['openai'] }],
+  ] as [PropOverrideKey, PropOverrideValue][]),
 };
 
 export const AppConfigContext: Context<AppConfig> = createContext(DEFAULT_APP_CONFIG);
 
 export function useAppConfig() {
   return useContext(AppConfigContext);
+}
+
+export function usePropOverrides<T>(Component: React.JSXElementConstructor<T>, defaultProps: T) {
+  const { propOverrides } = useAppConfig();
+  const overriddenProps = propOverrides.has(Component) ? propOverrides.get(Component) : {};
+  return { ...defaultProps, ...overriddenProps };
 }

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,6 +1,7 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
 import { Context, createContext, useContext } from 'react';
 
+// TODO: type safety here can be improved
 export type PropOverrideKey = React.JSXElementConstructor<never>;
 export type PropOverrideValue = { [key: string]: unknown };
 


### PR DESCRIPTION
First pass at a prop override system allowing any user of `@autoarena/ui` components to override their default props via the `AppConfig` context. This is useful to change behavior in different environments (e.g. local, cloud, on-prem deployments) without baking any notion of those environments into the base `@autoarena/ui` package.

Note that this does require components to explicitly opt into prop overrides by using this pattern:

```ts
export function MyComponent(props: Props) {
  const { ...myProps } = usePropOverrides(MyComponent, props);
  ...
```

The typing is not perfect, and the interface to set the overrides could be improved (`Map` has pretty poor devx) but the system works as-is and should prove a low-overhead way to customize application behavior.