### PR TITLE
Improve typing for UI `propOverrides`

### DIFF
--- a/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
+++ b/ui/src/components/Judges/CanAccessJudgeStatusIndicator.tsx
@@ -10,7 +10,7 @@ type Props = {
   CallToActionComponent?: ({ judgeType }: { judgeType: JudgeType }) => ReactNode;
 };
 export function CanAccessJudgeStatusIndicator(props: Props) {
-  const { judgeType, CallToActionComponent } = usePropOverrides(CanAccessJudgeStatusIndicator, props);
+  const { judgeType, CallToActionComponent } = usePropOverrides('CanAccessJudgeStatusIndicator', props);
   const { projectSlug = '' } = useUrlState();
   const { data: canAccess, isLoading } = useCanAccessJudgeType({ projectSlug, judgeType });
   const judgeTypeName = judgeTypeToHumanReadableName(judgeType);

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -14,7 +14,7 @@ type Props = {
   enabledJudges: JudgeType[];
 };
 export function Judges(props: Props) {
-  const { enabledJudges } = usePropOverrides(Judges, props);
+  const { enabledJudges } = usePropOverrides('Judges', props);
   const { projectSlug } = useUrlState();
   const { data: judges } = useJudges(projectSlug);
 

--- a/ui/src/components/MainMenu.tsx
+++ b/ui/src/components/MainMenu.tsx
@@ -9,7 +9,7 @@ type Props = {
   extraMenuItems?: ReactNode[];
 };
 export function MainMenu(props: Props) {
-  const { extraMenuItems } = usePropOverrides(MainMenu, props);
+  const { extraMenuItems } = usePropOverrides('MainMenu', props);
   const { appRoutes } = useAppRoutes();
 
   const iconProps = { size: 20, color: 'var(--mantine-color-kolena-light-color)' };

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -7,6 +7,7 @@ export type AppConfig = {
   basePath: string;
   apiFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   apiFetchEventSource: (input: RequestInfo, init: FetchEventSourceInit) => Promise<void>;
+  // components that consume prop overrides must register here
   propOverrides: Partial<{
     MainMenu: Partial<ComponentProps<typeof MainMenu>>;
     Judges: Partial<ComponentProps<typeof Judges>>;

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,16 +1,17 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
-import { Context, createContext, useContext } from 'react';
-
-// TODO: type safety here can be improved
-export type PropOverrideKey = React.JSXElementConstructor<never>;
-export type PropOverrideValue = { [key: string]: unknown };
+import { ComponentProps, Context, createContext, useContext } from 'react';
+import { CanAccessJudgeStatusIndicator, MainMenu, Judges } from '../components';
 
 export type AppConfig = {
   baseApiUrl: string;
   basePath: string;
   apiFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   apiFetchEventSource: (input: RequestInfo, init: FetchEventSourceInit) => Promise<void>;
-  propOverrides: Map<PropOverrideKey, PropOverrideValue>;
+  propOverrides: Partial<{
+    MainMenu: Partial<ComponentProps<typeof MainMenu>>;
+    Judges: Partial<ComponentProps<typeof Judges>>;
+    CanAccessJudgeStatusIndicator: Partial<ComponentProps<typeof CanAccessJudgeStatusIndicator>>;
+  }>;
 };
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
@@ -18,7 +19,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   basePath: '',
   apiFetch: fetch,
   apiFetchEventSource: fetchEventSource,
-  propOverrides: new Map(),
+  propOverrides: {},
 };
 
 export const AppConfigContext: Context<AppConfig> = createContext(DEFAULT_APP_CONFIG);
@@ -27,8 +28,8 @@ export function useAppConfig() {
   return useContext(AppConfigContext);
 }
 
-export function usePropOverrides<T>(Component: React.JSXElementConstructor<T>, defaultProps: T) {
+export function usePropOverrides<T>(componentName: keyof AppConfig['propOverrides'], defaultProps: T) {
   const { propOverrides } = useAppConfig();
-  const overriddenProps = propOverrides.has(Component) ? propOverrides.get(Component) : {};
+  const overriddenProps = propOverrides[componentName] ?? {};
   return { ...defaultProps, ...overriddenProps };
 }


### PR DESCRIPTION
Since components need to explicitly opt into allowing overridden props by using `usePropOverrides`, it makes sense to explicitly itemize them in AppConfig such that (a) components consuming overrides can be known by looking in one place and (b) typing is enforced when setting overrides.