### PR TITLE
Handle time zones in timestamps retrieved from SQLite

### DIFF
--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -20,7 +20,7 @@ class JudgeService:
                 SELECT
                     j.id,
                     j.judge_type,
-                    j.created,
+                    strftime('%Y-%m-%dT%H:%M:%SZ', j.created) AS created,
                     j.name,
                     j.model_name,
                     j.system_prompt,
@@ -80,7 +80,7 @@ class JudgeService:
                 """
                 INSERT INTO judge (judge_type, name, model_name, system_prompt, description, enabled)
                 VALUES (:judge_type, :name, :model_name, :system_prompt, :description, TRUE)
-                RETURNING id, created, enabled
+                RETURNING id, strftime('%Y-%m-%dT%H:%M:%SZ', created), enabled
                 """,
                 dict(
                     judge_type=request.judge_type.value,

--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -32,7 +32,7 @@ class ModelService:
         SELECT
             id,
             name,
-            created,
+            strftime('%Y-%m-%dT%H:%M:%SZ', created) AS created,
             elo,
             q025,
             q975,

--- a/tests/integration/api/test_judges.py
+++ b/tests/integration/api/test_judges.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tests.integration.api.conftest import CREATE_JUDGE_REQUEST
+from tests.integration.conftest import assert_recent
 
 
 def test__judges__default_human_judge(project_client: TestClient) -> None:
@@ -13,6 +14,7 @@ def test__judges__default_human_judge(project_client: TestClient) -> None:
     assert default_project_judges[0]["judge_type"] == "human"
     assert default_project_judges[0]["enabled"]
     assert default_project_judges[0]["n_votes"] == 0
+    assert_recent(default_project_judges[0]["created"])
 
 
 def test__judges__default_system_prompt(project_client: TestClient) -> None:
@@ -23,6 +25,7 @@ def test__judges__default_system_prompt(project_client: TestClient) -> None:
 
 def test__judges__create(project_client: TestClient) -> None:
     new_judge_dict = project_client.post("/judge", json=CREATE_JUDGE_REQUEST).json()
+    assert_recent(new_judge_dict["created"])
     for key in ["judge_type", "name", "model_name", "system_prompt", "description"]:
         assert new_judge_dict[key] == CREATE_JUDGE_REQUEST[key]
     assert project_client.get("/judges").json()[1] == new_judge_dict

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -28,7 +28,7 @@ def test__models__upload(project_client: TestClient, model_id: int) -> None:
     assert models[0]["name"] == "test-model-a"
     assert models[0]["n_responses"] == 2
     assert models[0]["n_votes"] == 0
-    assert_recent(models[0].created)
+    assert_recent(models[0]["created"])
 
 
 def test__models__upload__empty(project_client: TestClient) -> None:

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from autoarena.api import api
 from tests.integration.api.conftest import DF_RESPONSE, DF_RESPONSE_B, construct_upload_model_body
+from tests.integration.conftest import assert_recent
 
 
 @pytest.fixture
@@ -27,6 +28,7 @@ def test__models__upload(project_client: TestClient, model_id: int) -> None:
     assert models[0]["name"] == "test-model-a"
     assert models[0]["n_responses"] == 2
     assert models[0]["n_votes"] == 0
+    assert_recent(models[0].created)
 
 
 def test__models__upload__empty(project_client: TestClient) -> None:

--- a/tests/integration/api/test_tasks.py
+++ b/tests/integration/api/test_tasks.py
@@ -2,6 +2,8 @@ import json
 
 from fastapi.testclient import TestClient
 
+from tests.integration.conftest import assert_recent
+
 
 def parse_sse_stream(stream: bytes) -> list[dict]:
     return [json.loads(r.split("data: ")[-1]) for r in stream.decode("utf-8").split("\n\n") if r != ""]
@@ -16,6 +18,7 @@ def test__tasks__get(project_client: TestClient) -> None:
     assert tasks[0]["task_type"] == "fine-tune"
     assert tasks[0]["progress"] < 1
     assert len(tasks[0]["status"]) > 0
+    assert_recent(tasks[0]["created"])
 
 
 def test__tasks__has_active(project_client: TestClient) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import shutil
 import uuid
 from io import StringIO
@@ -63,3 +64,11 @@ def project_slug(api_v1_client: TestClient, test_data_directory: Path) -> Iterat
 def project_client(project_slug: Path) -> Iterator[TestClient]:
     with TestClient(server(), base_url=f"http://testserver{API_V1_STR}/project/{project_slug}") as client:
         yield client
+
+
+def assert_recent(timestamp: datetime.datetime | str) -> None:
+    if isinstance(timestamp, str):
+        timestamp = datetime.datetime.fromisoformat(timestamp)
+    now = datetime.datetime.now(datetime.UTC)
+    ten_seconds_ago = now - datetime.timedelta(seconds=10)
+    assert ten_seconds_ago < timestamp < now

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import shutil
 import uuid
 from io import StringIO
 from pathlib import Path
-from typing import Iterator, Callable
+from typing import Iterator, Callable, Union
 
 import pytest
 from fastapi.testclient import TestClient
@@ -66,7 +66,7 @@ def project_client(project_slug: Path) -> Iterator[TestClient]:
         yield client
 
 
-def assert_recent(timestamp: datetime.datetime | str) -> None:
+def assert_recent(timestamp: Union[datetime.datetime, str]) -> None:
     if isinstance(timestamp, str):
         timestamp = datetime.datetime.fromisoformat(timestamp)
     now = datetime.datetime.now(datetime.UTC)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,7 +68,9 @@ def project_client(project_slug: Path) -> Iterator[TestClient]:
 
 def assert_recent(timestamp: Union[datetime.datetime, str]) -> None:
     if isinstance(timestamp, str):
+        if timestamp.endswith("Z"):
+            timestamp = timestamp[:-1] + "+00:00"  # Python <=3.10 doesn't like 'Z' as a UTC indicator
         timestamp = datetime.datetime.fromisoformat(timestamp)
-    now = datetime.datetime.now(datetime.UTC)
+    now = datetime.datetime.now(datetime.timezone.utc)  # use datetime.timezone instead of datetime.UTC for <=3.10
     ten_seconds_ago = now - datetime.timedelta(seconds=10)
     assert ten_seconds_ago < timestamp < now

--- a/tests/integration/service/test_tasks.py
+++ b/tests/integration/service/test_tasks.py
@@ -14,6 +14,7 @@ from autoarena.service.judge import JudgeService
 from autoarena.service.model import ModelService
 from autoarena.service.task import TaskService
 from autoarena.task.auto_judge import AutoJudgeTask
+from tests.integration.conftest import assert_recent
 
 TEST_QUESTIONS = [
     dict(prompt="What is 2+2?", wrong="100 million", right="4"),
@@ -85,6 +86,7 @@ def test__task__auto_judge__models(
     assert tasks[0].progress == 1
     assert tasks[0].status is api.TaskStatus.COMPLETED
     assert len(tasks[0].logs) > 0
+    assert_recent(tasks[0].created)
 
 
 def test__task__auto_judge__many(
@@ -123,6 +125,7 @@ def test__task__auto_judge__no_head_to_heads(project_slug: str, enabled_auto_jud
     assert tasks[0].progress == 1
     assert tasks[0].status is api.TaskStatus.COMPLETED
     assert len(tasks[0].logs) > 0
+    assert_recent(tasks[0].created)
 
 
 def test__task__auto_judge__no_enabled_judges(
@@ -172,6 +175,7 @@ def test__task__recompute_leaderboard(project_slug: str, models_with_responses: 
     assert tasks[0].task_type is api.TaskType.RECOMPUTE_LEADERBOARD
     assert tasks[0].progress == 1
     assert len(tasks[0].status) > 0
+    assert_recent(tasks[0].created)
 
 
 def test__auto_judge_task__saves_progress(


### PR DESCRIPTION
Ensure that we are reading back timestamps as UTC timestamps such that the frontend can localize them accordingly. Without this special handling, they are loaded back timestamp-free, which can lead to weird behavior on the frontend like objects claiming to have been created in the future.