### PR TITLE
Enable WAL `journal_mode` with better write serialization

### DIFF
--- a/autoarena/api/router.py
+++ b/autoarena/api/router.py
@@ -61,6 +61,7 @@ def router(r: Optional[APIRouter] = None) -> APIRouter:
             df_response_by_model_name[value] = pd.read_csv(BytesIO(await file.read()))
         if len(df_response_by_model_name) == 0:
             raise BadRequestError("No valid model responses in body")
+        # TODO: ideally this would all take place within a single transaction
         new_models = [
             ModelService.upload_responses(project_slug, model_name, df_response)
             for model_name, df_response in df_response_by_model_name.items()

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -25,7 +25,7 @@ def get_database_connection(path: Path, commit: bool = False) -> Iterator[sqlite
         cur.execute("PRAGMA foreign_keys = ON")
         cur.execute("PRAGMA journal_mode = WAL")
         if commit:
-            cur.execute("BEGIN TRANSACTION")
+            cur.execute("BEGIN IMMEDIATE TRANSACTION")
         yield conn
         if commit:
             conn.commit()

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -30,7 +30,8 @@ def get_database_connection(path: Path, commit: bool = False) -> Iterator[sqlite
         if commit:
             conn.commit()
     except Exception as e:
-        conn.rollback()
+        if commit:
+            conn.rollback()
         raise e
     finally:
         conn.close()

--- a/autoarena/store/database.py
+++ b/autoarena/store/database.py
@@ -23,9 +23,15 @@ def get_database_connection(path: Path, commit: bool = False) -> Iterator[sqlite
         conn.create_function("id_slug", 2, id_slug)
         conn.create_function("invert_winner", 1, invert_winner)
         cur.execute("PRAGMA foreign_keys = ON")
+        cur.execute("PRAGMA journal_mode = WAL")
+        if commit:
+            cur.execute("BEGIN TRANSACTION")
         yield conn
         if commit:
             conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
     finally:
         conn.close()
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -24,3 +24,32 @@ def test__concurrent__read(n_readers: int, test_data_directory: Path) -> None:
 
     assert all(f.result() == [(1, "test")] for f in futures)
     assert time.time() - t0 < 5  # should be relatively fast; no blocking or waiting
+
+
+# up to 32 writers, 512 readers
+@pytest.mark.parametrize("n_writers, n_readers", [(2**i, 2 ** (i + 4)) for i in range(1, 6)])
+def test__concurrent__write(n_writers: int, n_readers: int, test_data_directory: Path) -> None:
+    database_file = test_data_directory / "test__concurrent__write.sqlite"
+    with get_database_connection(database_file, commit=True) as conn:
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO test (value) VALUES ('test')")
+
+    def read() -> list[tuple[str]]:
+        with get_database_connection(database_file) as conn_reader:
+            return conn_reader.cursor().execute("SELECT value FROM test WHERE id = 1").fetchall()
+
+    def write() -> None:
+        with get_database_connection(database_file, commit=True) as conn_writer:
+            conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent')")
+
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=n_writers + n_readers) as executor:
+        readers = [executor.submit(read) for _ in range(n_readers)]
+        writers = [executor.submit(write) for _ in range(n_writers)]
+
+    assert all(f.result() == [("test",)] for f in readers)
+    assert all(f.result() is None for f in writers)
+    assert time.time() - t0 < 5  # should be relatively fast; not much waiting
+
+    with get_database_connection(database_file) as conn:
+        assert conn.cursor().execute("SELECT COUNT(*) FROM test").fetchone() == (1 + n_writers,)

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -31,7 +31,7 @@ def test__concurrent__read(n_readers: int, test_data_directory: Path) -> None:
 def test__concurrent__write(n_writers: int, n_readers: int, test_data_directory: Path) -> None:
     database_file = test_data_directory / "test__concurrent__write.sqlite"
     with get_database_connection(database_file, commit=True) as conn:
-        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT UNIQUE)")
         conn.execute("INSERT INTO test (value) VALUES ('test')")
 
     def read() -> list[tuple[str]]:
@@ -40,7 +40,7 @@ def test__concurrent__write(n_writers: int, n_readers: int, test_data_directory:
 
     def write() -> None:
         with get_database_connection(database_file, commit=True) as conn_writer:
-            conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent')")
+            conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent-' || uuid())")
 
     t0 = time.time()
     with ThreadPoolExecutor(max_workers=n_writers + n_readers) as executor:

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -40,7 +40,7 @@ def test__concurrent__write(n_writers: int, n_readers: int, test_data_directory:
 
     def write() -> None:
         with get_database_connection(database_file, commit=True) as conn_writer:
-            conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent-' || uuid())")
+            conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent-' || hex(randomblob(32)))")
 
     t0 = time.time()
     with ThreadPoolExecutor(max_workers=n_writers + n_readers) as executor:

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,0 +1,26 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from autoarena.store.database import get_database_connection
+
+
+@pytest.mark.parametrize("n_readers", [2**i for i in range(1, 11)])  # up to 1024
+def test__concurrent__read(n_readers: int, test_data_directory: Path) -> None:
+    database_file = test_data_directory / "test__concurrent__read.sqlite"
+    with get_database_connection(database_file, commit=True) as conn:
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO test (value) VALUES ('test')")
+
+    def read() -> list[tuple[int, str]]:
+        with get_database_connection(database_file) as conn_reader:  # readonly connections
+            return conn_reader.cursor().execute("SELECT id, value FROM test").fetchall()
+
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=n_readers) as executor:
+        futures = [executor.submit(read) for _ in range(n_readers)]
+
+    assert all(f.result() == [(1, "test")] for f in futures)
+    assert time.time() - t0 < 5  # should be relatively fast; no blocking or waiting


### PR DESCRIPTION
Finding a better configuration/connection pattern to serialize writes. Waiting until other writes complete is fine; failing due to things like `Disk I/O error` is not. Using a WAL with writes in `BEGIN IMMEDIATE TRANSACTION` appears to be the sweet spot: reads are unlimited, and writes are serialized to avoid failures on concurrent write attempts.