### PR TITLE
Treat empty prompts and responses as empty strings

### DIFF
--- a/autoarena/service/model.py
+++ b/autoarena/service/model.py
@@ -96,13 +96,10 @@ class ModelService:
             raise BadRequestError(str(e))
         if len(df_response) == 0:
             raise BadRequestError("Responses must not be empty")
+        df_response = df_response.copy().replace({np.nan: ""})
         n_duplicate_prompts = len(df_response) - len(set(df_response["prompt"]))
         if n_duplicate_prompts > 0:
             raise BadRequestError(f"Each 'prompt' value must be unique (received {n_duplicate_prompts} duplicate(s))")
-        n_input = len(df_response)
-        df_response = df_response.copy().dropna(subset=["prompt", "response"])
-        if len(df_response) != n_input:
-            logger.warning(f"Dropped {n_input - len(df_response)} responses with empty prompt or response values")
         logger.info(f"Uploading {len(df_response)} responses from model '{model_name}'")
         with ProjectService.connect(project_slug, commit=True) as conn:
             cur = conn.cursor()

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -54,19 +54,30 @@ def test__models__upload__missing_columns(project_client: TestClient, df_bad: pd
 
 
 @pytest.mark.parametrize(
-    "df,n_dropped",
+    "df",
     [
-        (pd.DataFrame([("p", "r"), ("p2", "")], columns=["prompt", "response"]), 1),
-        (pd.DataFrame([("p", "r"), ("", "r")], columns=["prompt", "response"]), 1),
-        (pd.DataFrame([("p", ""), ("p2", "")], columns=["prompt", "response"]), 2),
-        (pd.DataFrame([("", "r"), ("p2", "")], columns=["prompt", "response"]), 2),
+        # many empty responses are fine
+        pd.DataFrame([("p", "r"), ("p2", ""), ("p3", None), ("p4", pd.NA)], columns=["prompt", "response"]),
+        # empty prompts are fine, treated as empty strings
+        pd.DataFrame([("p", "r"), (None, "r")], columns=["prompt", "response"]),
+        pd.DataFrame([("p", "r"), (pd.NA, "r")], columns=["prompt", "response"]),
+        pd.DataFrame([("p", "r"), ("", "r")], columns=["prompt", "response"]),
     ],
 )
-def test__models__upload__missing_values(project_client: TestClient, df: pd.DataFrame, n_dropped: int) -> None:
+def test__models__upload__missing_values(project_client: TestClient, df: pd.DataFrame) -> None:
     body = construct_upload_model_body(dict(example=df))
     models = project_client.post("/model", data=body.data, files=body.files).json()
     assert len(models) == 1
-    assert models[0]["n_responses"] == len(df) - n_dropped
+    assert models[0]["n_responses"] == len(df)
+
+
+def test__models__upload__missing_multiple_prompts(project_client: TestClient) -> None:
+    # empty prompts are treated as empty strings -- should fail due to duplicates
+    df = pd.DataFrame([(None, "r"), ("", "r2")], columns=["prompt", "response"])
+    body = construct_upload_model_body(dict(example=df))
+    response = project_client.post("/model", data=body.data, files=body.files)
+    assert response.status_code == 400
+    assert "Each 'prompt' value must be unique" in response.json()["detail"]
 
 
 def test__models__upload__duplicate_prompts(project_client: TestClient) -> None:


### PR DESCRIPTION
Update the handling of model responses to treat empty `prompt` or `response` cells as empty strings, rather than dropping those rows. This means that:

- Rows with empty `response` values are treated as if the model did not return anything, and can be evaluated head-to-head like any other response
- Rows with empty `prompt` values are treated as if the user did not input anything, meaning one such row is acceptable per model (under the `prompt` uniqueness constraint) but uploads with multiple empty prompts are rejected due to duplicate values