### PR TITLE
Attribute human votes to the user who provided them

### DIFF
--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -78,6 +78,7 @@ class HeadToHeadVoteRequest:  # this is always coming from humans
     response_a_id: int
     response_b_id: int
     winner: WinnerType
+    human_judge_name: str  # often 'human', sometimes a specific username
 
 
 class TaskType(str, Enum):

--- a/autoarena/api/api.py
+++ b/autoarena/api/api.py
@@ -78,7 +78,7 @@ class HeadToHeadVoteRequest:  # this is always coming from humans
     response_a_id: int
     response_b_id: int
     winner: WinnerType
-    human_judge_name: str  # often 'human', sometimes a specific username
+    human_judge_name: str  # often 'AutoArena User' but may be a specific username if one is available
 
 
 class TaskType(str, Enum):

--- a/autoarena/seed.py
+++ b/autoarena/seed.py
@@ -39,8 +39,8 @@ def seed_head_to_heads(head_to_heads: Path) -> None:
     df = df.rename(columns=dict(response_id="response_b_id"))
     df = df.dropna(subset=["response_a_id", "response_b_id"])
     df[["response_a_id", "response_b_id"]] = df[["response_a_id", "response_b_id"]].astype(int)
-    # TODO: allow seeding with non-human judgements?
-    df["judge_id"] = [j for j in JudgeService.get_all(project_slug) if j.judge_type is api.JudgeType.HUMAN][0].id
+    JudgeService.create_human_judge(project_slug, head_to_heads.name)
+    df["judge_id"] = [j for j in JudgeService.get_all(project_slug) if j.name == head_to_heads.name][0].id
     HeadToHeadService.upload_head_to_heads(project_slug, df[["response_a_id", "response_b_id", "judge_id", "winner"]])
 
     # 4. seed elo scores

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -116,14 +116,14 @@ class HeadToHeadService:
                 INSERT INTO head_to_head (response_id_slug, response_a_id, response_b_id, judge_id, winner)
                 SELECT :response_id_slug, :response_a_id, :response_b_id, j.id, :winner
                 FROM judge j
-                WHERE j.judge_type = :judge_type
+                WHERE j.name = :judge_name
                 ON CONFLICT (response_id_slug, judge_id) DO UPDATE SET
                     winner = IIF(response_a_id = :response_b_id, invert_winner(EXCLUDED.winner), EXCLUDED.winner)
             """,
                 dict(
                     **dataclasses.asdict(request),
                     response_id_slug=id_slug(request.response_a_id, request.response_b_id),
-                    judge_type=api.JudgeType.HUMAN.value,
+                    judge_name=request.human_judge_name,
                 ),
             )
 

--- a/autoarena/service/head_to_head.py
+++ b/autoarena/service/head_to_head.py
@@ -96,6 +96,7 @@ class HeadToHeadService:
     def submit_vote(project_slug: str, request: api.HeadToHeadVoteRequest) -> None:
         # 1. ensure judge exists
         JudgeService.create_human_judge(project_slug, request.human_judge_name)
+
         with ProjectService.connect(project_slug, commit=True) as conn:
             cur = conn.cursor()
 

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -114,7 +114,7 @@ class JudgeService:
                 dict(
                     judge_type=api.JudgeType.HUMAN.value,
                     name=name,
-                    description="Manual ratings submitted via the 'Head-to-Head' tab",
+                    description="Manual votes submitted via the 'Head-to-Head' tab",
                 ),
             )
 

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -103,7 +103,7 @@ class JudgeService:
         )
 
     @staticmethod
-    def create_default_human_judge(project_slug: str) -> None:
+    def create_human_judge(project_slug: str, name: str = api.JudgeType.HUMAN.value) -> None:
         with ProjectService.connect(project_slug, commit=True) as conn:
             conn.cursor().execute(
                 """
@@ -113,7 +113,7 @@ class JudgeService:
             """,
                 dict(
                     judge_type=api.JudgeType.HUMAN.value,
-                    name=api.JudgeType.HUMAN.value,
+                    name=name,
                     description="Manual ratings submitted via the 'Head-to-Head' tab",
                 ),
             )

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -102,9 +102,8 @@ class JudgeService:
             n_votes=0,
         )
 
-    # TODO: is this necessary?
     @staticmethod
-    def create_human_judge(project_slug: str) -> api.Judge:
+    def create_default_human_judge(project_slug: str) -> None:
         with ProjectService.connect(project_slug, commit=True) as conn:
             conn.cursor().execute(
                 """
@@ -118,8 +117,6 @@ class JudgeService:
                     description="Manual ratings submitted via the 'Head-to-Head' tab",
                 ),
             )
-        # TODO: this is a little lazy but ¯\_(ツ)_/¯
-        return [j for j in JudgeService.get_all(project_slug) if j.judge_type is api.JudgeType.HUMAN][0]
 
     @staticmethod
     def update(project_slug: str, judge_id: int, request: api.UpdateJudgeRequest) -> api.Judge:

--- a/autoarena/service/judge.py
+++ b/autoarena/service/judge.py
@@ -103,7 +103,7 @@ class JudgeService:
         )
 
     @staticmethod
-    def create_human_judge(project_slug: str, name: str = api.JudgeType.HUMAN.value) -> None:
+    def create_human_judge(project_slug: str, name: str) -> None:
         with ProjectService.connect(project_slug, commit=True) as conn:
             conn.cursor().execute(
                 """

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -28,14 +28,12 @@ class ProjectService:
     @staticmethod
     def create_idempotent(request: api.CreateProjectRequest) -> api.Project:
         # TODO: should come up with a better way than this to have services point at one another, or remove the need
-        from autoarena.service.judge import JudgeService
 
         data_directory = DataDirectoryProvider.get()
         data_directory.mkdir(parents=True, exist_ok=True)
         path = data_directory / f"{request.name}.sqlite"
         slug = ProjectService._path_to_slug(path)
         ProjectService._setup_database(path)
-        JudgeService.create_human_judge(slug)
         return api.Project(slug=slug, filename=path.name, filepath=str(path))
 
     @staticmethod

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -35,7 +35,7 @@ class ProjectService:
         path = data_directory / f"{request.name}.sqlite"
         slug = ProjectService._path_to_slug(path)
         ProjectService._setup_database(path)
-        JudgeService.create_human_judge(slug)
+        JudgeService.create_default_human_judge(slug)
         return api.Project(slug=slug, filename=path.name, filepath=str(path))
 
     @staticmethod

--- a/autoarena/service/project.py
+++ b/autoarena/service/project.py
@@ -35,7 +35,7 @@ class ProjectService:
         path = data_directory / f"{request.name}.sqlite"
         slug = ProjectService._path_to_slug(path)
         ProjectService._setup_database(path)
-        JudgeService.create_default_human_judge(slug)
+        JudgeService.create_human_judge(slug)
         return api.Project(slug=slug, filename=path.name, filepath=str(path))
 
     @staticmethod

--- a/tests/integration/api/test_head_to_head.py
+++ b/tests/integration/api/test_head_to_head.py
@@ -62,8 +62,8 @@ def test__head_to_head__submit_vote__with_name(project_client: TestClient, model
     assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
     judges = project_client.get("/judges").json()
-    assert len(judges) == 2
-    assert h2h[0]["history"] == [dict(judge_id=judges[1]["id"], judge_name=judges[1]["name"], winner="A")]
+    assert len(judges) == 1
+    assert h2h[0]["history"] == [dict(judge_id=judges[0]["id"], judge_name=judges[0]["name"], winner="A")]
     assert h2h[1]["history"] == []
 
 

--- a/tests/integration/api/test_head_to_head.py
+++ b/tests/integration/api/test_head_to_head.py
@@ -34,10 +34,11 @@ def test__head_to_head__get(project_client: TestClient, model_id: int, model_b_i
 def test__head_to_head__submit_vote(project_client: TestClient, model_id: int, model_b_id: int) -> None:
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
     response_a_id, response_b_id = h2h[0]["response_a_id"], h2h[0]["response_b_id"]
-    judge_request = dict(response_a_id=response_a_id, response_b_id=response_b_id, winner="A")
+    judge_request = dict(response_a_id=response_a_id, response_b_id=response_b_id, winner="A", human_judge_name="human")
     assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
     judges = project_client.get("/judges").json()
+    assert len(judges) == 1
     assert h2h[0]["history"] == [dict(judge_id=judges[0]["id"], judge_name=judges[0]["name"], winner="A")]
     assert h2h[1]["history"] == []
 
@@ -46,10 +47,23 @@ def test__head_to_head__submit_vote(project_client: TestClient, model_id: int, m
     assert h2h[0]["history"] == [dict(judge_id=judges[0]["id"], judge_name=judges[0]["name"], winner="B")]
 
     # overwrite previous vote
-    judge_request = dict(response_a_id=response_a_id, response_b_id=response_b_id, winner="B")
+    judge_request = dict(response_a_id=response_a_id, response_b_id=response_b_id, winner="B", human_judge_name="human")
     assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
     assert h2h[0]["history"] == [dict(judge_id=judges[0]["id"], judge_name=judges[0]["name"], winner="B")]
+    assert h2h[1]["history"] == []
+
+
+def test__head_to_head__submit_vote__with_name(project_client: TestClient, model_id: int, model_b_id: int) -> None:
+    h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
+    response_a_id, response_b_id = h2h[0]["response_a_id"], h2h[0]["response_b_id"]
+    name = "testuser@example.com"
+    judge_request = dict(response_a_id=response_a_id, response_b_id=response_b_id, winner="A", human_judge_name=name)
+    assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
+    h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
+    judges = project_client.get("/judges").json()
+    assert len(judges) == 2
+    assert h2h[0]["history"] == [dict(judge_id=judges[1]["id"], judge_name=judges[1]["name"], winner="A")]
     assert h2h[1]["history"] == []
 
 

--- a/tests/integration/api/test_judges.py
+++ b/tests/integration/api/test_judges.py
@@ -59,9 +59,19 @@ def test__judges__can_access__unrecognized__failed(project_client: TestClient) -
 
 def test__judges__download_votes_csv(project_client: TestClient, model_id: int, model_b_id: int) -> None:
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
-    judge_request = dict(response_a_id=h2h[0]["response_a_id"], response_b_id=h2h[0]["response_b_id"], winner="A")
+    judge_request = dict(
+        response_a_id=h2h[0]["response_a_id"],
+        response_b_id=h2h[0]["response_b_id"],
+        winner="A",
+        human_judge_name="human",
+    )
     assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
-    judge_request = dict(response_a_id=h2h[1]["response_b_id"], response_b_id=h2h[1]["response_a_id"], winner="-")
+    judge_request = dict(
+        response_a_id=h2h[1]["response_b_id"],
+        response_b_id=h2h[1]["response_a_id"],
+        winner="-",
+        human_judge_name="human",
+    )
     assert project_client.post("/head-to-head/vote", json=judge_request).json() is None
     judges = project_client.get("/judges").json()
     assert len(judges) == 1

--- a/tests/integration/api/test_models.py
+++ b/tests/integration/api/test_models.py
@@ -13,7 +13,12 @@ from tests.integration.conftest import assert_recent
 def n_model_a_votes(project_client: TestClient, model_id: int, model_b_id: int) -> int:
     h2h = project_client.put("/head-to-heads", json=dict(model_a_id=model_id, model_b_id=model_b_id)).json()
     for h in h2h:
-        request = dict(response_a_id=h["response_a_id"], response_b_id=h["response_b_id"], winner="A")
+        request = dict(
+            response_a_id=h["response_a_id"],
+            response_b_id=h["response_b_id"],
+            winner="A",
+            human_judge_name="human",
+        )
         assert project_client.post("/head-to-head/vote", json=request).json() is None
     return len(h2h)
 

--- a/tests/integration/service/test_tasks.py
+++ b/tests/integration/service/test_tasks.py
@@ -159,7 +159,12 @@ def test__task__recompute_leaderboard(project_slug: str, models_with_responses: 
     model_a, model_b = models_with_responses
     h2hs = HeadToHeadService.get(project_slug, api.HeadToHeadsRequest(model_a_id=model_a.id, model_b_id=model_b.id))
     for h2h in h2hs:
-        vote = api.HeadToHeadVoteRequest(response_a_id=h2h.response_a_id, response_b_id=h2h.response_b_id, winner="A")
+        vote = api.HeadToHeadVoteRequest(
+            response_a_id=h2h.response_a_id,
+            response_b_id=h2h.response_b_id,
+            winner="A",
+            human_judge_name="test-user",
+        )
         HeadToHeadService.submit_vote(project_slug, vote)
     models_before = ModelService.get_all(project_slug)
     TaskService.recompute_leaderboard(project_slug)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -27,12 +27,13 @@ def test__cli__seed(test_data_directory: Path) -> None:
     ]
     df_h2h_input = pd.DataFrame.from_records(h2h_records)
     with tempfile.NamedTemporaryFile(suffix=".csv") as f:
-        filename = f.name
+        filepath = f.name
         df_h2h_input.to_csv(f, index=False)
-        main(["seed", filename])
+        main(["seed", filepath])
 
     projects = ProjectService.get_all()
-    project_slug = Path(filename).stem
+    judge_name = Path(filepath).name
+    project_slug = Path(filepath).stem
     assert len(projects) == 1
     assert projects[0].slug == project_slug
 
@@ -47,7 +48,7 @@ def test__cli__seed(test_data_directory: Path) -> None:
         df_h2h_input_model = df_h2h_input[(df_h2h_input.model_a == model.name) | (df_h2h_input.model_b == model.name)]
         assert len(df_h2h_model) == len(df_h2h_input_model)
         assert all(df_h2h_model.history.apply(lambda h: len(h) == 1))
-        assert all(df_h2h_model.history.apply(lambda h: h[0]["judge_name"] == "human"))
+        assert all(df_h2h_model.history.apply(lambda h: h[0]["judge_name"] == judge_name))
 
 
 def test__cli__seed__missing_argument(test_data_directory: None) -> None:

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -24,7 +24,7 @@ type Props = {
   humanJudgeName?: string;
 };
 export function HeadToHeadTwoModels(props: Props) {
-  const { modelAId, modelBId, humanJudgeName = 'human' } = usePropOverrides('HeadToHeadTwoModels', props);
+  const { modelAId, modelBId, humanJudgeName = 'AutoArena User' } = usePropOverrides('HeadToHeadTwoModels', props);
   const { projectSlug = '' } = useUrlState();
   const { appRoutes } = useAppRoutes();
   const navigate = useNavigate();

--- a/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
+++ b/ui/src/components/HeadToHead/HeadToHeadTwoModels.tsx
@@ -11,7 +11,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import { useDisclosure, useElementSize, useHotkeys } from '@mantine/hooks';
 import { useNavigate } from 'react-router-dom';
 import { useHeadToHeads, useUrlState, useSubmitHeadToHeadVote, useModel, useAppRoutes } from '../../hooks';
-import { pluralize } from '../../lib';
+import { pluralize, usePropOverrides } from '../../lib';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { NonIdealState } from '../NonIdealState.tsx';
 import { ControlBar } from './ControlBar.tsx';
@@ -21,8 +21,10 @@ type ShowMode = 'All' | 'With Votes' | 'Without Votes';
 type Props = {
   modelAId: number;
   modelBId: number;
+  humanJudgeName?: string;
 };
-export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
+export function HeadToHeadTwoModels(props: Props) {
+  const { modelAId, modelBId, humanJudgeName = 'human' } = usePropOverrides('HeadToHeadTwoModels', props);
   const { projectSlug = '' } = useUrlState();
   const { appRoutes } = useAppRoutes();
   const navigate = useNavigate();
@@ -67,6 +69,7 @@ export function HeadToHeadTwoModels({ modelAId, modelBId }: Props) {
           response_a_id: headToHead.response_a_id,
           response_b_id: headToHead.response_b_id,
           winner: vote,
+          human_judge_name: humanJudgeName,
         });
         setHeadToHeadIndex(prev => prev + 1);
       }

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -60,7 +60,7 @@ export function JudgeAccordionItem({ judge }: Props) {
         <Group justify="space-between" pl="xs" pr="lg">
           <Stack gap={0}>
             <Text c={!isEnabled ? 'gray.6' : undefined}>
-              {judge_type === 'human' || name === 'human' ? (
+              {judge_type === 'human' && name === 'human' ? (
                 judgeTypeToHumanReadableName(judge_type)
               ) : (
                 <>

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -6,7 +6,7 @@ import { IconDownload, IconGavel, IconPrompt } from '@tabler/icons-react';
 import { Judge, useUpdateJudge, useUrlState, useDownloadFile, useAppRoutes } from '../../hooks';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { pluralize } from '../../lib';
-import { isDefaultHumanJudge, judgeTypeIconComponent, judgeTypeToHumanReadableName } from './types.ts';
+import { judgeTypeIconComponent, judgeTypeToHumanReadableName } from './types.ts';
 import { DeleteJudgeButton } from './DeleteJudgeButton.tsx';
 import { CanAccessJudgeStatusIndicator } from './CanAccessJudgeStatusIndicator.tsx';
 import { TriggerAutoJudgeModal } from './TriggerAutoJudgeModal.tsx';
@@ -60,16 +60,10 @@ export function JudgeAccordionItem({ judge }: Props) {
         <Group justify="space-between" pl="xs" pr="lg">
           <Stack gap={0}>
             <Text c={!isEnabled ? 'gray.6' : undefined}>
-              {isDefaultHumanJudge(judge) ? (
-                judgeTypeToHumanReadableName(judge_type)
-              ) : (
-                <>
-                  {name}{' '}
-                  <Text span c="dimmed">
-                    ({judgeTypeToHumanReadableName(judge_type)})
-                  </Text>
-                </>
-              )}
+              {name}{' '}
+              <Text span c="dimmed">
+                ({judgeTypeToHumanReadableName(judge_type)})
+              </Text>
             </Text>
             <Text c="dimmed" size="xs">
               {description}

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -6,7 +6,12 @@ import { IconDownload, IconGavel, IconPrompt } from '@tabler/icons-react';
 import { Judge, useUpdateJudge, useUrlState, useDownloadFile, useAppRoutes } from '../../hooks';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { pluralize } from '../../lib';
-import { judgeTypeIconComponent, judgeTypeToHumanReadableName } from './types.ts';
+import {
+  DEFAULT_HUMAN_JUDGE_NAME,
+  isDefaultHumanJudge,
+  judgeTypeIconComponent,
+  judgeTypeToHumanReadableName,
+} from './types.ts';
 import { DeleteJudgeButton } from './DeleteJudgeButton.tsx';
 import { CanAccessJudgeStatusIndicator } from './CanAccessJudgeStatusIndicator.tsx';
 import { TriggerAutoJudgeModal } from './TriggerAutoJudgeModal.tsx';
@@ -60,7 +65,7 @@ export function JudgeAccordionItem({ judge }: Props) {
         <Group justify="space-between" pl="xs" pr="lg">
           <Stack gap={0}>
             <Text c={!isEnabled ? 'gray.6' : undefined}>
-              {judge_type === 'human' && name === 'human' ? (
+              {isDefaultHumanJudge(judge) ? (
                 judgeTypeToHumanReadableName(judge_type)
               ) : (
                 <>
@@ -145,6 +150,7 @@ export function JudgeAccordionItem({ judge }: Props) {
                 tab to provide ratings on head-to-head matchups between models.
               </Text>
               {DownloadVotesComponent}
+              {!isDefaultHumanJudge(judge) && <DeleteJudgeButton judge={judge} />}
             </Group>
           )}
           <Collapse in={showSystemPrompt} fz="sm">

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -6,12 +6,7 @@ import { IconDownload, IconGavel, IconPrompt } from '@tabler/icons-react';
 import { Judge, useUpdateJudge, useUrlState, useDownloadFile, useAppRoutes } from '../../hooks';
 import { MarkdownContent } from '../MarkdownContent.tsx';
 import { pluralize } from '../../lib';
-import {
-  DEFAULT_HUMAN_JUDGE_NAME,
-  isDefaultHumanJudge,
-  judgeTypeIconComponent,
-  judgeTypeToHumanReadableName,
-} from './types.ts';
+import { isDefaultHumanJudge, judgeTypeIconComponent, judgeTypeToHumanReadableName } from './types.ts';
 import { DeleteJudgeButton } from './DeleteJudgeButton.tsx';
 import { CanAccessJudgeStatusIndicator } from './CanAccessJudgeStatusIndicator.tsx';
 import { TriggerAutoJudgeModal } from './TriggerAutoJudgeModal.tsx';
@@ -149,8 +144,10 @@ export function JudgeAccordionItem({ judge }: Props) {
                 </Link>{' '}
                 tab to provide ratings on head-to-head matchups between models.
               </Text>
-              {DownloadVotesComponent}
-              {!isDefaultHumanJudge(judge) && <DeleteJudgeButton judge={judge} />}
+              <Group>
+                {DownloadVotesComponent}
+                {!isDefaultHumanJudge(judge) && <DeleteJudgeButton judge={judge} />}
+              </Group>
             </Group>
           )}
           <Collapse in={showSystemPrompt} fz="sm">

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -146,7 +146,7 @@ export function JudgeAccordionItem({ judge }: Props) {
               </Text>
               <Group>
                 {DownloadVotesComponent}
-                {!isDefaultHumanJudge(judge) && <DeleteJudgeButton judge={judge} />}
+                <DeleteJudgeButton judge={judge} />
               </Group>
             </Group>
           )}

--- a/ui/src/components/Judges/JudgeAccordionItem.tsx
+++ b/ui/src/components/Judges/JudgeAccordionItem.tsx
@@ -60,15 +60,15 @@ export function JudgeAccordionItem({ judge }: Props) {
         <Group justify="space-between" pl="xs" pr="lg">
           <Stack gap={0}>
             <Text c={!isEnabled ? 'gray.6' : undefined}>
-              {judge_type !== 'human' ? (
+              {judge_type === 'human' || name === 'human' ? (
+                judgeTypeToHumanReadableName(judge_type)
+              ) : (
                 <>
                   {name}{' '}
                   <Text span c="dimmed">
                     ({judgeTypeToHumanReadableName(judge_type)})
                   </Text>
                 </>
-              ) : (
-                'Human'
               )}
             </Text>
             <Text c="dimmed" size="xs">

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -1,7 +1,7 @@
 import { Accordion, Anchor, Center, Divider, SimpleGrid, Stack, Title, Text, Code, Paper } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { ReactNode } from 'react';
-import { Judge, useJudges, useUrlState } from '../../hooks';
+import { useJudges, useUrlState } from '../../hooks';
 import { ExternalUrls, usePropOverrides } from '../../lib';
 import { APP_CONTENT_WIDTH } from '../constants.ts';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
@@ -16,7 +16,8 @@ type Props = {
 export function Judges(props: Props) {
   const { enabledJudges } = usePropOverrides('Judges', props);
   const { projectSlug } = useUrlState();
-  const { data: judges = [] }: { data: Judge[] } = useJudges(projectSlug);
+  const { data: queryJudges } = useJudges(projectSlug);
+  const judges = queryJudges ?? [];
 
   const availableJudges: { [judgeType in JudgeType]: () => ReactNode } = {
     custom: CreateFineTunedJudgeCard,

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from 'react';
 import { Judge, useJudges, useUrlState } from '../../hooks';
 import { ExternalUrls, usePropOverrides } from '../../lib';
 import { APP_CONTENT_WIDTH } from '../constants.ts';
-import { NonIdealState } from '../NonIdealState.tsx';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
 import { CreateJudgeModal } from './CreateJudgeModal.tsx';
 import { CreateFineTunedJudgeModal } from './CreateFineTunedJudgeModal.tsx';
@@ -40,8 +39,12 @@ export function Judges(props: Props) {
           {judges.length > 0 ? (
             judges.map(judge => <JudgeAccordionItem key={judge.id} judge={judge} />)
           ) : (
-            <Paper withBorder>
-              <NonIdealState description="No judges configured" />
+            <Paper withBorder p={24} /* 24px padding is very close to the size of a single accordion item */>
+              <Center>
+                <Text c="dimmed" fs="italic" size="sm">
+                  No judges configured
+                </Text>
+              </Center>
             </Paper>
           )}
         </Accordion>

--- a/ui/src/components/Judges/Judges.tsx
+++ b/ui/src/components/Judges/Judges.tsx
@@ -1,9 +1,10 @@
-import { Accordion, Anchor, Center, Divider, SimpleGrid, Stack, Title, Text, Code } from '@mantine/core';
+import { Accordion, Anchor, Center, Divider, SimpleGrid, Stack, Title, Text, Code, Paper } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { ReactNode } from 'react';
-import { useJudges, useUrlState } from '../../hooks';
+import { Judge, useJudges, useUrlState } from '../../hooks';
 import { ExternalUrls, usePropOverrides } from '../../lib';
 import { APP_CONTENT_WIDTH } from '../constants.ts';
+import { NonIdealState } from '../NonIdealState.tsx';
 import { ConfigureJudgeCard } from './ConfigureJudgeCard.tsx';
 import { CreateJudgeModal } from './CreateJudgeModal.tsx';
 import { CreateFineTunedJudgeModal } from './CreateFineTunedJudgeModal.tsx';
@@ -16,7 +17,7 @@ type Props = {
 export function Judges(props: Props) {
   const { enabledJudges } = usePropOverrides('Judges', props);
   const { projectSlug } = useUrlState();
-  const { data: judges } = useJudges(projectSlug);
+  const { data: judges = [] }: { data: Judge[] } = useJudges(projectSlug);
 
   const availableJudges: { [judgeType in JudgeType]: () => ReactNode } = {
     custom: CreateFineTunedJudgeCard,
@@ -36,9 +37,13 @@ export function Judges(props: Props) {
       <Stack w={APP_CONTENT_WIDTH}>
         <Title order={5}>Configured Judges</Title>
         <Accordion variant="contained">
-          {(judges ?? []).map(judge => (
-            <JudgeAccordionItem key={judge.id} judge={judge} />
-          ))}
+          {judges.length > 0 ? (
+            judges.map(judge => <JudgeAccordionItem key={judge.id} judge={judge} />)
+          ) : (
+            <Paper withBorder>
+              <NonIdealState description="No judges configured" />
+            </Paper>
+          )}
         </Accordion>
 
         <Divider />

--- a/ui/src/components/Judges/index.ts
+++ b/ui/src/components/Judges/index.ts
@@ -9,4 +9,3 @@ export * from './JudgeAccordionItem';
 export * from './Judges';
 export * from './TriggerAutoJudgeModal';
 export * from './types';
-export * from './utils';

--- a/ui/src/components/Judges/types.ts
+++ b/ui/src/components/Judges/types.ts
@@ -127,7 +127,3 @@ export function judgeTypeToApiKeyName(judgeType: JudgeType) {
 export function isEnabledAutoJudge(judge: Judge) {
   return judge.enabled && judge.judge_type !== 'human';
 }
-
-export function isDefaultHumanJudge(judge: Judge) {
-  return judge.judge_type === 'human' && judge.name === 'human';
-}

--- a/ui/src/components/Judges/types.ts
+++ b/ui/src/components/Judges/types.ts
@@ -17,6 +17,7 @@ import cohereUrl from '../../../assets/cohere.jpg';
 import togetherUrl from '../../../assets/together.jpg';
 import bedrockUrl from '../../../assets/bedrock.jpg';
 import customUrl from '../../../assets/custom.jpg';
+import { Judge } from '../../hooks';
 
 export type JudgeType =
   | 'human'
@@ -121,4 +122,12 @@ export function judgeTypeToApiKeyName(judgeType: JudgeType) {
     case 'together':
       return 'TOGETHER_API_KEY';
   }
+}
+
+export function isEnabledAutoJudge(judge: Judge) {
+  return judge.enabled && judge.judge_type !== 'human';
+}
+
+export function isDefaultHumanJudge(judge: Judge) {
+  return judge.judge_type === 'human' && judge.name === 'human';
 }

--- a/ui/src/components/Judges/utils.ts
+++ b/ui/src/components/Judges/utils.ts
@@ -1,5 +1,0 @@
-import { Judge } from '../../hooks';
-
-export function isEnabledAutoJudge(judge: Judge) {
-  return judge.enabled && judge.judge_type !== 'human';
-}

--- a/ui/src/hooks/useSubmitHeadToHeadVote.ts
+++ b/ui/src/hooks/useSubmitHeadToHeadVote.ts
@@ -6,6 +6,7 @@ type HeadToHeadVoteRequest = {
   response_a_id: number;
   response_b_id: number;
   winner: 'A' | 'B' | '-';
+  human_judge_name: string;
 };
 
 type Params = {

--- a/ui/src/lib/appConfig.ts
+++ b/ui/src/lib/appConfig.ts
@@ -1,6 +1,6 @@
 import { fetchEventSource, FetchEventSourceInit } from '@microsoft/fetch-event-source';
 import { ComponentProps, Context, createContext, useContext } from 'react';
-import { CanAccessJudgeStatusIndicator, MainMenu, Judges } from '../components';
+import { CanAccessJudgeStatusIndicator, MainMenu, Judges, HeadToHeadTwoModels } from '../components';
 
 export type AppConfig = {
   baseApiUrl: string;
@@ -12,6 +12,7 @@ export type AppConfig = {
     MainMenu: Partial<ComponentProps<typeof MainMenu>>;
     Judges: Partial<ComponentProps<typeof Judges>>;
     CanAccessJudgeStatusIndicator: Partial<ComponentProps<typeof CanAccessJudgeStatusIndicator>>;
+    HeadToHeadTwoModels: Partial<ComponentProps<typeof HeadToHeadTwoModels>>;
   }>;
 };
 


### PR DESCRIPTION
When information about the user is available (i.e. when logged into AutoArena Cloud), store votes from the head-to-head tab as coming from that specific user, rather than the generic `human` judge. This allows for teams to collaborate on manual ratings, and see how different users from an org voted.

By default, human votes are now shown as coming from "AutoArena User":

![Screenshot 2024-10-03 at 4 16 16 PM](https://github.com/user-attachments/assets/fad18492-003b-4b28-b0dd-b6dbfcdf629c)
