### PR TITLE
Add process-level parallelism to `uvicorn.run`

### DIFF
--- a/autoarena/main.py
+++ b/autoarena/main.py
@@ -46,5 +46,6 @@ def main(args: list[str]) -> None:
             port=8899,
             reload=getattr(parsed_args, "dev", False),
             factory=True,
+            workers=8,  # parallelize with N processes when reload is False
             timeout_graceful_shutdown=1,  # wait 1 second for tasks to complete before forcefully exiting
         )

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,5 +1,5 @@
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import pytest
@@ -53,3 +53,37 @@ def test__concurrent__write(n_writers: int, n_readers: int, test_data_directory:
 
     with get_database_connection(database_file) as conn:
         assert conn.cursor().execute("SELECT COUNT(*) FROM test").fetchone() == (1 + n_writers,)
+
+
+def multiproc_read_write(database_file: Path, n_readers: int) -> list[list[tuple[str]]]:
+    def read() -> list[tuple[str]]:
+        with get_database_connection(database_file) as conn_reader:
+            return conn_reader.cursor().execute("SELECT value FROM test WHERE id = 1").fetchall()
+
+    with ThreadPoolExecutor(max_workers=n_readers) as executor:
+        readers = [executor.submit(read) for _ in range(n_readers)]
+
+    with get_database_connection(database_file, commit=True) as conn_writer:
+        conn_writer.cursor().execute("INSERT INTO test (value) VALUES ('concurrent-' || hex(randomblob(32)))")
+
+    return [future.result() for future in as_completed(readers)]
+
+
+# up to 16 subprocesses that both read and write
+@pytest.mark.parametrize("n_subprocesses", [(2**i) for i in range(1, 5)])
+def test__multiprocessing(n_subprocesses: int, test_data_directory: Path) -> None:
+    database_file = test_data_directory / "test__multiprocessing.sqlite"
+    with get_database_connection(database_file, commit=True) as conn:
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT UNIQUE)")
+        conn.execute("INSERT INTO test (value) VALUES ('test')")
+
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=n_subprocesses * 2) as executor:
+        futures = [executor.submit(multiproc_read_write, database_file, 32) for _ in range(n_subprocesses)]
+
+    responses = [response for future in futures for response in future.result()]
+    assert all(response == [("test",)] for response in responses)
+    assert time.time() - t0 < 5  # should be relatively fast; not much waiting
+
+    with get_database_connection(database_file) as conn:
+        assert conn.cursor().execute("SELECT COUNT(*) FROM test").fetchone() == (1 + n_subprocesses,)


### PR DESCRIPTION
Enable multiple worker processes when running the app in normal mode (not `--dev`) and add test verifying that database reads and writes behave as expected under these conditions.